### PR TITLE
fix(bump): don't fetch the complete repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Fixed
+- The bump action no longer tries to fetch the repository's complete commit history, but is limited to the last 100 commits and tags.
+
 ## [2.0.0] - 2022-09-28
 ### Removed
 - Python no longer needs to be installed in order to run this action

--- a/dist/bump/index.js
+++ b/dist/bump/index.js
@@ -12633,14 +12633,18 @@ function run() {
     return __awaiter(this, void 0, void 0, function* () {
         try {
             const { owner, repo } = github_2.context.repo;
-            const commits = yield octokit.paginate(octokit.rest.repos.listCommits, {
+            core.debug(`Fetching last 100 commits from ${github_2.context.sha}..`);
+            const { data: commits } = yield octokit.rest.repos.listCommits({
                 owner: owner,
                 repo: repo,
                 sha: github_2.context.sha,
+                per_page: 100,
             });
-            const tags = yield octokit.paginate(octokit.rest.repos.listTags, {
+            core.debug("Fetching last 100 tags in repo..");
+            const { data: tags } = yield octokit.rest.repos.listTags({
                 owner: owner,
                 repo: repo,
+                per_page: 100,
             });
             core.startGroup("🔍 Finding latest topological tag..");
             let latest_semver = null;

--- a/src/actions/bump.ts
+++ b/src/actions/bump.ts
@@ -51,14 +51,18 @@ const octokit = getOctokit(core.getInput("token"));
 async function run() {
   try {
     const { owner, repo } = context.repo;
-    const commits = await octokit.paginate(octokit.rest.repos.listCommits, {
+    core.debug(`Fetching last 100 commits from ${context.sha}..`);
+    const { data: commits } = await octokit.rest.repos.listCommits({
       owner: owner,
       repo: repo,
       sha: context.sha,
+      per_page: 100,
     });
-    const tags = await octokit.paginate(octokit.rest.repos.listTags, {
+    core.debug("Fetching last 100 tags in repo..");
+    const { data: tags } = await octokit.rest.repos.listTags({
       owner: owner,
       repo: repo,
+      per_page: 100,
     });
     core.startGroup("🔍 Finding latest topological tag..");
 


### PR DESCRIPTION
Paginating like the original implementation doesn't go down well on a large repository; we only fetch 100 parents now.

Also, add some debug logging before the Octokit calls.