### PR TITLE
fix: apply `disable`-configuration parameter

### DIFF
--- a/dist/bump/index.js
+++ b/dist/bump/index.js
@@ -11988,7 +11988,7 @@ module.exports = { ConventionalCommitMessage };
  * limitations under the License.
  */
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.Configuration = void 0;
+exports._testData = exports.Configuration = void 0;
 const rules_1 = __nccwpck_require__(1058);
 const fs = __nccwpck_require__(7147);
 const yaml = __nccwpck_require__(4083);
@@ -12105,6 +12105,10 @@ class Configuration {
     }
 }
 exports.Configuration = Configuration;
+/* Exports for tests only */
+exports._testData = {
+    DEFAULT_ACCEPTED_TAGS,
+};
 
 
 /***/ }),

--- a/dist/bump/index.js
+++ b/dist/bump/index.js
@@ -12026,7 +12026,7 @@ class Configuration {
         this.allowed_branches = ".*";
         this.tags = DEFAULT_ACCEPTED_TAGS;
         this.ignore = DEFAULT_IGNORED_RULES;
-        this.rules = {};
+        this.rules = new Map();
         // Enable all rules by default
         for (const rule of rules_1.ALL_RULES) {
             this.rules[rule.id] = {
@@ -12051,6 +12051,11 @@ class Configuration {
             }
             switch (key) {
                 case "disable":
+                    /* Example YAML:
+                     *   disable:
+                     *     - C001
+                     *     - C018
+                     */
                     if (typeof data[key] === "object") {
                         for (const item of data[key]) {
                             this.rules[item].enabled = false;
@@ -12490,9 +12495,12 @@ const logging_1 = __nccwpck_require__(1517);
  */
 function validateRules(message, config) {
     let errors = [];
+    const disabledRules = Object.entries(config.rules)
+        .map(([k, v]) => (!v.enabled ? k : undefined))
+        .filter((r) => !!r);
     for (const rule of exports.ALL_RULES) {
         try {
-            if (!(rule.id in config.ignore)) {
+            if (!disabledRules.includes(rule.id)) {
                 rule.validate(message, config);
             }
         }

--- a/dist/cli/index.js
+++ b/dist/cli/index.js
@@ -2256,7 +2256,7 @@ module.exports = { ConventionalCommitMessage };
  * limitations under the License.
  */
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.Configuration = void 0;
+exports._testData = exports.Configuration = void 0;
 const rules_1 = __nccwpck_require__(1058);
 const fs = __nccwpck_require__(7147);
 const yaml = __nccwpck_require__(4083);
@@ -2373,6 +2373,10 @@ class Configuration {
     }
 }
 exports.Configuration = Configuration;
+/* Exports for tests only */
+exports._testData = {
+    DEFAULT_ACCEPTED_TAGS,
+};
 
 
 /***/ }),

--- a/dist/cli/index.js
+++ b/dist/cli/index.js
@@ -2294,7 +2294,7 @@ class Configuration {
         this.allowed_branches = ".*";
         this.tags = DEFAULT_ACCEPTED_TAGS;
         this.ignore = DEFAULT_IGNORED_RULES;
-        this.rules = {};
+        this.rules = new Map();
         // Enable all rules by default
         for (const rule of rules_1.ALL_RULES) {
             this.rules[rule.id] = {
@@ -2319,6 +2319,11 @@ class Configuration {
             }
             switch (key) {
                 case "disable":
+                    /* Example YAML:
+                     *   disable:
+                     *     - C001
+                     *     - C018
+                     */
                     if (typeof data[key] === "object") {
                         for (const item of data[key]) {
                             this.rules[item].enabled = false;
@@ -2556,9 +2561,12 @@ const logging_1 = __nccwpck_require__(1517);
  */
 function validateRules(message, config) {
     let errors = [];
+    const disabledRules = Object.entries(config.rules)
+        .map(([k, v]) => (!v.enabled ? k : undefined))
+        .filter((r) => !!r);
     for (const rule of exports.ALL_RULES) {
         try {
-            if (!(rule.id in config.ignore)) {
+            if (!disabledRules.includes(rule.id)) {
                 rule.validate(message, config);
             }
         }

--- a/dist/validate/index.js
+++ b/dist/validate/index.js
@@ -11594,7 +11594,7 @@ module.exports = { ConventionalCommitMessage };
  * limitations under the License.
  */
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.Configuration = void 0;
+exports._testData = exports.Configuration = void 0;
 const rules_1 = __nccwpck_require__(1058);
 const fs = __nccwpck_require__(7147);
 const yaml = __nccwpck_require__(4083);
@@ -11711,6 +11711,10 @@ class Configuration {
     }
 }
 exports.Configuration = Configuration;
+/* Exports for tests only */
+exports._testData = {
+    DEFAULT_ACCEPTED_TAGS,
+};
 
 
 /***/ }),

--- a/dist/validate/index.js
+++ b/dist/validate/index.js
@@ -11632,7 +11632,7 @@ class Configuration {
         this.allowed_branches = ".*";
         this.tags = DEFAULT_ACCEPTED_TAGS;
         this.ignore = DEFAULT_IGNORED_RULES;
-        this.rules = {};
+        this.rules = new Map();
         // Enable all rules by default
         for (const rule of rules_1.ALL_RULES) {
             this.rules[rule.id] = {
@@ -11657,6 +11657,11 @@ class Configuration {
             }
             switch (key) {
                 case "disable":
+                    /* Example YAML:
+                     *   disable:
+                     *     - C001
+                     *     - C018
+                     */
                     if (typeof data[key] === "object") {
                         for (const item of data[key]) {
                             this.rules[item].enabled = false;
@@ -12096,9 +12101,12 @@ const logging_1 = __nccwpck_require__(1517);
  */
 function validateRules(message, config) {
     let errors = [];
+    const disabledRules = Object.entries(config.rules)
+        .map(([k, v]) => (!v.enabled ? k : undefined))
+        .filter((r) => !!r);
     for (const rule of exports.ALL_RULES) {
         try {
-            if (!(rule.id in config.ignore)) {
+            if (!disabledRules.includes(rule.id)) {
                 rule.validate(message, config);
             }
         }

--- a/src/config.ts
+++ b/src/config.ts
@@ -157,3 +157,8 @@ export class Configuration {
     }
   }
 }
+
+/* Exports for tests only */
+export const _testData = {
+  DEFAULT_ACCEPTED_TAGS,
+};

--- a/src/config.ts
+++ b/src/config.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { IRuleConfigItem } from "./interfaces";
 import { ALL_RULES } from "./rules";
 
 const fs = require("fs");
@@ -51,7 +52,7 @@ export class Configuration {
   allowed_branches: string = ".*";
   tags: {} = DEFAULT_ACCEPTED_TAGS;
   ignore: string[] = DEFAULT_IGNORED_RULES;
-  rules: {} = {};
+  rules: Map<string, IRuleConfigItem> = new Map<string, IRuleConfigItem>();
 
   private loadFromData(data: any) {
     for (const key in data) {
@@ -61,6 +62,11 @@ export class Configuration {
 
       switch (key) {
         case "disable":
+          /* Example YAML:
+           *   disable:
+           *     - C001
+           *     - C018
+           */
           if (typeof data[key] === "object") {
             for (const item of data[key]) {
               this.rules[item].enabled = false;

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -26,3 +26,8 @@ export interface IVersionBumpTypeAndMessages {
    * the commit associated with the nearest SemVer tag */
   messages: ConventionalCommitMessage[];
 }
+
+export interface IRuleConfigItem {
+  description: string;
+  enabled: boolean;
+}

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -39,9 +39,13 @@ export function validateRules(
 ) {
   let errors: LlvmError[] = [];
 
+  const disabledRules = Object.entries(config.rules)
+    .map(([k, v]) => (!v.enabled ? k : undefined))
+    .filter((r): r is string => !!r);
+
   for (const rule of ALL_RULES) {
     try {
-      if (!(rule.id in config.ignore)) {
+      if (!disabledRules.includes(rule.id)) {
         rule.validate(message, config);
       }
     } catch (error) {

--- a/test/commit.test.ts
+++ b/test/commit.test.ts
@@ -333,7 +333,9 @@ describe("Configurable options", () => {
           - C016
         `),
       () => {
-        new ConventionalCommitMessage("fix: updated testing");
+        expect(() => {
+          new ConventionalCommitMessage("fix: updated testing");
+        }).not.toThrow(ConventionalCommitError);
       }
     );
   });


### PR DESCRIPTION
The `disable` keyword in the Configuration file was not applied correctly when executing the ruleset for Conventional Commit-message checking.

Fixes: #114