### PR TITLE
fix(imperative-mood-rule): check only first word of description

### DIFF
--- a/dist/bump/index.js
+++ b/dist/bump/index.js
@@ -13209,7 +13209,7 @@ class DescriptionInImperativeMood {
             "verifies",
             "verifying",
         ];
-        if (message.description.match(new RegExp(`${common_non_imperative_verbs.join("|")}`, "i"))) {
+        if (message.description.match(new RegExp(`^(${common_non_imperative_verbs.join("|")})`, "i"))) {
             const msg = new logging_1.LlvmError();
             msg.message = `[${this.id}] ${this.description}`;
             msg.line = message.subject;

--- a/dist/cli/index.js
+++ b/dist/cli/index.js
@@ -5838,7 +5838,7 @@ class DescriptionInImperativeMood {
             "verifies",
             "verifying",
         ];
-        if (message.description.match(new RegExp(`${common_non_imperative_verbs.join("|")}`, "i"))) {
+        if (message.description.match(new RegExp(`^(${common_non_imperative_verbs.join("|")})`, "i"))) {
             const msg = new logging_1.LlvmError();
             msg.message = `[${this.id}] ${this.description}`;
             msg.line = message.subject;

--- a/dist/validate/index.js
+++ b/dist/validate/index.js
@@ -12791,7 +12791,7 @@ class DescriptionInImperativeMood {
             "verifies",
             "verifying",
         ];
-        if (message.description.match(new RegExp(`${common_non_imperative_verbs.join("|")}`, "i"))) {
+        if (message.description.match(new RegExp(`^(${common_non_imperative_verbs.join("|")})`, "i"))) {
             const msg = new logging_1.LlvmError();
             msg.message = `[${this.id}] ${this.description}`;
             msg.line = message.subject;

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -487,7 +487,7 @@ class DescriptionInImperativeMood implements IConventionalCommitRule {
     ];
     if (
       message.description.match(
-        new RegExp(`${common_non_imperative_verbs.join("|")}`, "i")
+        new RegExp(`^(${common_non_imperative_verbs.join("|")})`, "i")
       )
     ) {
       const msg = new LlvmError();

--- a/test/rules.test.ts
+++ b/test/rules.test.ts
@@ -401,6 +401,7 @@ describe("Rules", () => {
       "chore: this is a chore",
       "feat(scope)!: breaking change with scope",
       "chore: remove API call",
+      "fix(ttlock): use new traffic-client that has updated gtest",
     ]) {
       assertRuleNoValidationError(message, getConventionalCommitRule("C016"));
     }


### PR DESCRIPTION
The check was intended to work this way as can be seen from the way the error message is created (it references the first word).