### PR TITLE
feat: add PR title bump level validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ jobs:
 | Item | Mandatory | Description |
 | --- | --- | --- |
 | `token` | YES | GitHub Token provided by GitHub, see [Authenticating with the GITHUB_TOKEN] |
-| `validate-pull-request` | NO | Includes the Pull Request title and description as part of the Conventional Commit validation (DEFAULT: `false`) |
+| `validate-pull-request` | NO | Includes the Pull Request title and description as part of the Conventional Commit validation (DEFAULT: `true`) |
+| `validate-pull-request-title-bump` | NO | Ensures that the Pull Request title's version bump level matches that of its commits (DEFAULT: `true`) |
 | `validate-commits` | NO | Includes commits associated with the current Pull Request as part of the Conventional Commit validation (DEFAULT: `true`) |
 | `config` | NO | Location of the Commisery configuration file (default: `.commisery.yml`)
 

--- a/action.yml
+++ b/action.yml
@@ -32,6 +32,11 @@ inputs:
     required: false
     default: true
 
+  validate-pull-request-title-bump:
+    description: 'Validates the version bump level of the Pull Request title against the highest bump level in its commits'
+    required: false
+    default: true
+
   validate-commits:
     description: 'Validates the commits within the current context'
     required: false

--- a/dist/bump/index.js
+++ b/dist/bump/index.js
@@ -12478,7 +12478,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.getAssociatedPullRequests = exports.getTags = exports.getCommitsSince = exports.getConfig = exports.createTag = exports.createRelease = exports.getPullRequest = exports.getCommits = exports.getPullRequestId = exports.isPullRequestEvent = void 0;
+exports.getAssociatedPullRequests = exports.getTags = exports.getCommitsSince = exports.getConfig = exports.createTag = exports.createRelease = exports.getPullRequest = exports.getCommits = exports.getPullRequestTitle = exports.getPullRequestId = exports.isPullRequestEvent = void 0;
 const core = __importStar(__nccwpck_require__(2186));
 const fs = __importStar(__nccwpck_require__(7147));
 const github = __importStar(__nccwpck_require__(5438));
@@ -12504,6 +12504,15 @@ function getPullRequestId() {
     return github.context.issue.number;
 }
 exports.getPullRequestId = getPullRequestId;
+/**
+ * The current pull request's title
+ */
+function getPullRequestTitle() {
+    return __awaiter(this, void 0, void 0, function* () {
+        return (yield getPullRequest(getPullRequestId())).title;
+    });
+}
+exports.getPullRequestTitle = getPullRequestTitle;
 /**
  * Retrieves a list of commits associated with the specified Pull Request
  * @param pullrequest_id GitHub Pullrequest ID

--- a/src/actions/validate.ts
+++ b/src/actions/validate.ts
@@ -18,7 +18,11 @@ import * as core from "@actions/core";
 
 import { Configuration } from "../config";
 import { getConfig, isPullRequestEvent } from "../github";
-import { getMessagesToValidate, validateMessages } from "../validate";
+import {
+  getMessagesToValidate,
+  validateMessages,
+  validatePrTitleBump,
+} from "../validate";
 
 async function run(): Promise<void> {
   try {
@@ -36,6 +40,9 @@ async function run(): Promise<void> {
     // Validate each commit against Conventional Commit standard
     const messages = await getMessagesToValidate();
     await validateMessages(messages, config);
+    if (core.getBooleanInput("validate-pull-request-title-bump")) {
+      await validatePrTitleBump(config);
+    }
   } catch (ex) {
     core.setFailed((ex as Error).message);
   }

--- a/src/github.ts
+++ b/src/github.ts
@@ -45,6 +45,13 @@ export function getPullRequestId(): number {
 }
 
 /**
+ * The current pull request's title
+ */
+export async function getPullRequestTitle(): Promise<string> {
+  return (await getPullRequest(getPullRequestId())).title;
+}
+
+/**
  * Retrieves a list of commits associated with the specified Pull Request
  * @param pullrequest_id GitHub Pullrequest ID
  * @returns List of commit objects


### PR DESCRIPTION
This introduces a new check which ensures the pull request title
represents the same bump level as the highest bump level in the
list of commits associated with that pull request.

The check can be disabled by setting `validate-pull-request-title-bump`
action input to `false`.
