### PR TITLE
feat: add support from build metadata on version bump

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,10 +92,11 @@ jobs:
         uses: tomtom-international/commisery-action/bump@v1
         with:
           token: ${{ github.token }}
-          create-release: true  # OPTIONAL, default: `false`
-          create-tag: false  # OPTIONAL
-          version-prefix: v  # OPTIONAL
-          config: .commisery.yml # OPTIONAL
+          create-release: true              # OPTIONAL, default: `false`
+          create-tag: false                 # OPTIONAL
+          build-metadata: upstream-10.0.10  # OPTIONAL
+          version-prefix: v                 # OPTIONAL
+          config: .commisery.yml            # OPTIONAL
 
       - run: echo "Current version is ${{steps.release-version.outputs.current-version}}"
 
@@ -115,8 +116,9 @@ Commit messages, for example:
 | `token` | YES | GitHub Token provided by GitHub, see [Authenticating with the GITHUB_TOKEN]|
 | `create-release` | NO | Can optionally be set to `true` to create a GitHub release on version bump.|
 | `create-tag` | NO | Can optionally be set to `true` to create a lightweight Git tag on version bump.|
-| `version-prefix` | NO | An optional prefix specifying the tags to consider, eg. `v`, `componentX-`, `""`.
-| `config` | NO | Location of the Commisery configuration file (default: `.commisery.yml`)
+| `build-metadata` | NO | Build metadata to add to the SemVer version on version bump.|
+| `version-prefix` | NO | An optional prefix specifying the tags to consider, eg. `v`, `componentX-`, `""`.|
+| `config` | NO | Location of the Commisery configuration file (default: `.commisery.yml`)|
 
 > :bulb: Note that setting both `create-release` and `create-tag` to `true` is never needed, since a GitHub
 release implicitly creates a Git tag.

--- a/bump/action.yml
+++ b/bump/action.yml
@@ -30,6 +30,9 @@ inputs:
   token:
     description: 'GitHub token used to access GitHub (eg. github.token)'
     required: true
+  build-metadata:
+    description: 'Optional SemVer build metadata'
+    required: false
   create-release:
     description: 'Create a GitHub Release if a version bump is performed (outside a pull request event)'
     default: false

--- a/dist/bump/index.js
+++ b/dist/bump/index.js
@@ -11520,6 +11520,11 @@ function run() {
             core.startGroup("🔍 Determining bump");
             const nextVersion = bumpInfo.foundVersion.bump(bumpInfo.requiredBump);
             if (nextVersion) {
+                // Assign Build Metadata
+                const build_metadata = core.getInput("build-metadata");
+                if (build_metadata) {
+                    nextVersion.build = build_metadata;
+                }
                 const nv = nextVersion.to_string();
                 core.info(`ℹ️ Next version: ${nv}`);
                 core.setOutput("next-version", nv);
@@ -13491,6 +13496,19 @@ class SemVer {
         this.prerelease = prerelease;
         this.build = build;
         this.prefix = prefix;
+    }
+    get build() {
+        return this._build;
+    }
+    set build(build_metadata) {
+        if (build_metadata !== "") {
+            for (const identifier of build_metadata.split(".")) {
+                if (/[^0-9A-Za-z-]/.test(identifier) || identifier.length === 0) {
+                    throw new Error(`Provided build metadata (${build_metadata}) does not comply to the SemVer specification`);
+                }
+            }
+        }
+        this._build = build_metadata;
     }
     static from_string(version) {
         const match = SEMVER_RE.exec(version);

--- a/dist/cli/index.js
+++ b/dist/cli/index.js
@@ -6112,6 +6112,19 @@ class SemVer {
         this.build = build;
         this.prefix = prefix;
     }
+    get build() {
+        return this._build;
+    }
+    set build(build_metadata) {
+        if (build_metadata !== "") {
+            for (const identifier of build_metadata.split(".")) {
+                if (/[^0-9A-Za-z-]/.test(identifier) || identifier.length === 0) {
+                    throw new Error(`Provided build metadata (${build_metadata}) does not comply to the SemVer specification`);
+                }
+            }
+        }
+        this._build = build_metadata;
+    }
     static from_string(version) {
         const match = SEMVER_RE.exec(version);
         if (match != null && match.groups != null) {

--- a/dist/validate/index.js
+++ b/dist/validate/index.js
@@ -13077,6 +13077,19 @@ class SemVer {
         this.build = build;
         this.prefix = prefix;
     }
+    get build() {
+        return this._build;
+    }
+    set build(build_metadata) {
+        if (build_metadata !== "") {
+            for (const identifier of build_metadata.split(".")) {
+                if (/[^0-9A-Za-z-]/.test(identifier) || identifier.length === 0) {
+                    throw new Error(`Provided build metadata (${build_metadata}) does not comply to the SemVer specification`);
+                }
+            }
+        }
+        this._build = build_metadata;
+    }
     static from_string(version) {
         const match = SEMVER_RE.exec(version);
         if (match != null && match.groups != null) {

--- a/src/actions/bump.ts
+++ b/src/actions/bump.ts
@@ -102,6 +102,12 @@ async function run(): Promise<void> {
       bumpInfo.requiredBump
     );
     if (nextVersion) {
+      // Assign Build Metadata
+      const build_metadata = core.getInput("build-metadata");
+      if (build_metadata) {
+        nextVersion.build = build_metadata;
+      }
+
       const nv = nextVersion.to_string();
       core.info(`ℹ️ Next version: ${nv}`);
       core.setOutput("next-version", nv);

--- a/src/semver.ts
+++ b/src/semver.ts
@@ -44,8 +44,8 @@ export class SemVer {
   minor: number;
   patch: number;
   prerelease: string;
-  build: string;
   prefix: string;
+  private _build!: string;
 
   constructor(
     major: number,
@@ -61,6 +61,23 @@ export class SemVer {
     this.prerelease = prerelease;
     this.build = build;
     this.prefix = prefix;
+  }
+
+  get build(): string {
+    return this._build;
+  }
+
+  set build(build_metadata: string) {
+    if (build_metadata !== "") {
+      for (const identifier of build_metadata.split(".")) {
+        if (/[^0-9A-Za-z-]/.test(identifier) || identifier.length === 0) {
+          throw new Error(
+            `Provided build metadata (${build_metadata}) does not comply to the SemVer specification`
+          );
+        }
+      }
+    }
+    this._build = build_metadata;
   }
 
   static from_string(version: string): SemVer | null {

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -65,9 +65,7 @@ describe("Configurable options", () => {
   });
 
   test("Disable nonexistent rule", () => {
-    const core_warning = jest
-      .spyOn(core, "warning")
-      .mockImplementation();
+    const core_warning = jest.spyOn(core, "warning").mockImplementation();
 
     withConfig(
       dedent(`

--- a/test/semver.test.ts
+++ b/test/semver.test.ts
@@ -138,3 +138,26 @@ describe("Semantic Version ordering", () => {
     ).toBe(true);
   });
 });
+
+describe("Build Metadata", () => {
+  test("Missing Build Metadata", () => {
+    expect(() => {
+      new SemVer(1, 2, 3, "4", "", "5");
+    }).not.toThrow(Error);
+  });
+  test("Valid Build Metadata", () => {
+    expect(() => {
+      new SemVer(1, 2, 3, "4", "identifier-1.identifier-2", "5");
+    }).not.toThrow(Error);
+  });
+  test("Invalid Build Metadata", () => {
+    expect(() => {
+      new SemVer(1, 2, 3, "4", "identifier-1.identifier-2&wrong", "5");
+    }).toThrow(Error);
+  });
+  test("Empty Indentifier in Build Metadata", () => {
+    expect(() => {
+      new SemVer(1, 2, 3, "4", "identifier-1..identifier-2", "5");
+    }).toThrow(Error);
+  });
+});


### PR DESCRIPTION
This commit allows you to specify the SemVer Build-metadata to apply in the new version after bumping;

```
      - name: Release version
        id: release-version
        uses: tomtom-international/commisery-action/bump@v1
        with:
          token: ${{ github.token }}
          create-release: true              # OPTIONAL, default: `false`
          create-tag: false                 # OPTIONAL
          build-metadata: upstream-10.0.10  # OPTIONAL
          version-prefix: v                 # OPTIONAL
          config: .commisery.yml            # OPTIONAL
```

The above example will result in a version similar to: `1.2.3+upstream-10.0.0`

Signed-off-by: Kevin de Jong <kevin.dejong@tomtom.com>