### PR TITLE
feat: add support for Initial Development

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ jobs:
 
 ![example](https://github.com/tomtom-international/commisery-action/raw/master/resources/example.png)
 
-### Create GitHub Releases based on unreleased Conventional Commits
+## Create GitHub Releases based on unreleased Conventional Commits
 
 With the `/bump` GitHub Action, you can create a new Git tag or a GitHub release (also implicitly a Git tag),
 based on the types of [Conventional Commits] since the latest found [Semantic Versioning]-compatible tag.
@@ -73,6 +73,20 @@ Filtering the Git version tags is also possible, by providing a `version-prefix`
 _exactly_ with the value of `version-prefix` shall be taken into account while determining and bumping versions.
 As an example, for version tag `componentX-1.2.3`, the version prefix would be `componentX-`.
 
+### Initial Development
+
+During initial development, you should avoid bumping the `MAJOR` version.
+By default, we will bump the `MINOR` version for breaking changes in case:
+- The current `MAJOR`-version is `0`
+- **AND** the `initial-development` configuration parameter is `true` (default value)
+
+We will automatically bump the version to `1.0.0` when:
+- The current `MAJOR`-version is `0`
+- **AND** the `initial-development` configuration parameter is `false`
+
+> NOTE: This behavior also applies to non-bumping commits (ie. `chore:`, `ci:`)
+
+### Example workflow
 An example workflow that creates a release on every commit or merge to the `main` branch if necessary:
 
 ```yml
@@ -155,6 +169,7 @@ allowed-branches: "^ma(in|ster)$"
 | `tags` | `fix`, `feat`, `build`, `chore`, `ci`, `docs`, `perf`, `refactor`, `revert`, `style`, `test`, `improvement` | Specify a custom list of Conventional Commit types to allow. If provided, this will overwrite the default list, so be sure to include those if you want to retain them.<br>`tags` takes a dict per type tag, with two values that can be set:<ul><li>`description`: a human-readable description of what the type should be used for.</li><li>`bump`: if set to `true`, will cause commits with this type to also bump the `PATCH` version component, same as `fix`.</li></ul>If you only specify YAML string, it shall be treated as the `description`; the `bump` will be `false` implicitly. <br><br>**NOTE:** The type tags `feat` and `fix` will automatically be provided. |
 | `disabled` | `None` | List of rules to disable as part of the checker |
 | `allowed-branches` | `.*` | A regex specifying from which branch(es) releases and Git tags are allowed to be created |
+| `initial-development` | `true` | A boolean indicating that this project is still under _initial development_. During this state, any commit message containing a breaking change will result in a `MINOR` version bump. |
 
 > :bulb: By default `commisery-action` will search for the file `.commisery.yml`. 
 You can specify a different file with the `config` input parameter.

--- a/dist/bump/index.js
+++ b/dist/bump/index.js
@@ -11519,6 +11519,11 @@ function run() {
             core.endGroup();
             core.startGroup("🔍 Determining bump");
             const nextVersion = bumpInfo.foundVersion.bump(bumpInfo.requiredBump, config.initial_development);
+            if (bumpInfo.foundVersion.major <= 0) {
+                core.warning(config.initial_development
+                    ? "This repository is under 'initial development'; breaking changes will bump the `MINOR` version."
+                    : "Enforcing version `1.0.0` as we are no longer in `initial development`.");
+            }
             if (nextVersion) {
                 // Assign Build Metadata
                 const build_metadata = core.getInput("build-metadata");

--- a/dist/bump/index.js
+++ b/dist/bump/index.js
@@ -11512,7 +11512,7 @@ function run() {
                 return;
             }
             else {
-                const currentVersion = bumpInfo.foundVersion.to_string();
+                const currentVersion = bumpInfo.foundVersion.toString();
                 core.info(`ℹ️ Found SemVer tag: ${currentVersion}`);
                 core.setOutput("current-version", currentVersion);
             }
@@ -11525,7 +11525,7 @@ function run() {
                 if (build_metadata) {
                     nextVersion.build = build_metadata;
                 }
-                const nv = nextVersion.to_string();
+                const nv = nextVersion.toString();
                 core.info(`ℹ️ Next version: ${nv}`);
                 core.setOutput("next-version", nv);
                 core.endGroup();
@@ -11660,7 +11660,7 @@ function getSemVerIfMatches(prefix, tagName, tagSha, commitSha) {
             core.debug(`Tag '${tag}' on commit '${commit.slice(0, 6)}' ${message}`);
         };
         // If provided, make sure that the prefix matches as well
-        const sv = semver_1.SemVer.from_string(tagName);
+        const sv = semver_1.SemVer.fromString(tagName);
         if (sv) {
             // Asterisk is a special case, meaning 'any prefix'
             if (sv.prefix === prefix || prefix === "*") {
@@ -11897,8 +11897,8 @@ function generateChangelog(bump) {
                 }
             }
         }
-        const diff_range = `${bump.foundVersion.to_string()}...${(_b = bump.foundVersion
-            .bump(bump.requiredBump)) === null || _b === void 0 ? void 0 : _b.to_string()}`;
+        const diff_range = `${bump.foundVersion.toString()}...${(_b = bump.foundVersion
+            .bump(bump.requiredBump)) === null || _b === void 0 ? void 0 : _b.toString()}`;
         changelog_formatted += `\n\n*Diff since last release: [${diff_range}](https://github.com/${owner}/${repo}/compare/${diff_range})*`;
         return changelog_formatted;
     });
@@ -13523,7 +13523,7 @@ class SemVer {
         }
         this._build = build_metadata;
     }
-    static from_string(version) {
+    static fromString(version) {
         const match = SEMVER_RE.exec(version);
         if (match != null && match.groups != null) {
             return new SemVer({
@@ -13537,12 +13537,12 @@ class SemVer {
         }
         return null;
     }
-    to_string() {
+    toString() {
         const prerelease = this.prerelease ? `-${this.prerelease}` : "";
         const build = this.build ? `+${this.build}` : "";
         return `${this.prefix}${this.major}.${this.minor}.${this.patch}${prerelease}${build}`;
     }
-    next_major() {
+    nextMajor() {
         return new SemVer({
             major: this.major + 1,
             minor: 0,
@@ -13550,7 +13550,7 @@ class SemVer {
             prefix: this.prefix,
         });
     }
-    next_minor() {
+    nextMinor() {
         return new SemVer({
             major: this.major,
             minor: this.minor + 1,
@@ -13558,7 +13558,7 @@ class SemVer {
             prefix: this.prefix,
         });
     }
-    next_patch() {
+    nextPatch() {
         if (this.prerelease !== "") {
             return new SemVer({
                 major: this.major,
@@ -13596,13 +13596,13 @@ class SemVer {
                 if (initial_development && this.major <= 0) {
                     // Bumping major version during initial development is prohibited,
                     // bump the minor version instead.
-                    return this.next_minor();
+                    return this.nextMinor();
                 }
-                return this.next_major();
+                return this.nextMajor();
             case SemVerType.MINOR:
-                return this.next_minor();
+                return this.nextMinor();
             case SemVerType.PATCH:
-                return this.next_patch();
+                return this.nextPatch();
             default:
                 return null;
         }

--- a/dist/bump/index.js
+++ b/dist/bump/index.js
@@ -11518,7 +11518,7 @@ function run() {
             }
             core.endGroup();
             core.startGroup("🔍 Determining bump");
-            const nextVersion = bumpInfo.foundVersion.bump(bumpInfo.requiredBump);
+            const nextVersion = bumpInfo.foundVersion.bump(bumpInfo.requiredBump, config.initial_development);
             if (nextVersion) {
                 // Assign Build Metadata
                 const build_metadata = core.getInput("build-metadata");
@@ -12219,6 +12219,7 @@ const CONFIG_ITEMS = [
     "tags",
     "disable",
     "allowed-branches",
+    "initial-development",
 ];
 /**
  * This function takes two values and throws when their types don't match.
@@ -12240,8 +12241,9 @@ class Configuration {
      * Constructs a Configuration parameters from file
      */
     constructor(config_path = DEFAULT_CONFIGURATION_FILE) {
-        this.max_subject_length = 80;
         this.allowed_branches = ".*";
+        this.initial_development = true;
+        this.max_subject_length = 80;
         this.tags = DEFAULT_ACCEPTED_TAGS;
         this.rules = new Map();
         // Enable all rules by default
@@ -12367,6 +12369,17 @@ class Configuration {
                     }
                     else {
                         throw new Error(`Incorrect type '${typeof data[key]}' for '${key}', must be '${typeof this.allowed_branches}'!`);
+                    }
+                    break;
+                case "initial-development":
+                    /* Example YAML
+                     *   initial-development: true
+                     */
+                    if (typeof data[key] === "boolean") {
+                        this.initial_development = data[key];
+                    }
+                    else {
+                        throw new Error(`Incorrect type '${typeof data[key]}' for '${key}', must be '${typeof this.initial_development}'!`);
                     }
                     break;
             }
@@ -13489,7 +13502,7 @@ var SemVerType;
     SemVerType[SemVerType["MAJOR"] = 3] = "MAJOR";
 })(SemVerType = exports.SemVerType || (exports.SemVerType = {}));
 class SemVer {
-    constructor(major, minor, patch, prerelease, build, prefix) {
+    constructor({ major, minor, patch, prerelease = "", build = "", prefix = "", }) {
         this.major = major;
         this.minor = minor;
         this.patch = patch;
@@ -13513,7 +13526,14 @@ class SemVer {
     static from_string(version) {
         const match = SEMVER_RE.exec(version);
         if (match != null && match.groups != null) {
-            return new SemVer(+match.groups.major, +match.groups.minor, +match.groups.patch, match.groups.prerelease || "", match.groups.build || "", match.groups.prefix || "");
+            return new SemVer({
+                major: +match.groups.major,
+                minor: +match.groups.minor,
+                patch: +match.groups.patch,
+                prerelease: match.groups.prerelease || "",
+                build: match.groups.build || "",
+                prefix: match.groups.prefix || "",
+            });
         }
         return null;
     }
@@ -13523,24 +13543,61 @@ class SemVer {
         return `${this.prefix}${this.major}.${this.minor}.${this.patch}${prerelease}${build}`;
     }
     next_major() {
-        return new SemVer(this.major + 1, 0, 0, "", "", this.prefix);
+        return new SemVer({
+            major: this.major + 1,
+            minor: 0,
+            patch: 0,
+            prefix: this.prefix,
+        });
     }
     next_minor() {
-        return new SemVer(this.major, this.minor + 1, 0, "", "", this.prefix);
+        return new SemVer({
+            major: this.major,
+            minor: this.minor + 1,
+            patch: 0,
+            prefix: this.prefix,
+        });
     }
     next_patch() {
         if (this.prerelease !== "") {
-            return new SemVer(this.major, this.minor, this.patch, "", "", this.prefix);
+            return new SemVer({
+                major: this.major,
+                minor: this.minor,
+                patch: this.patch,
+                prefix: this.prefix,
+            });
         }
-        return new SemVer(this.major, this.minor, this.patch + 1, "", "", this.prefix);
+        return new SemVer({
+            major: this.major,
+            minor: this.minor,
+            patch: this.patch + 1,
+            prefix: this.prefix,
+        });
     }
     /**
      * Returns a new SemVer object bumped by the provided bump type, or `null` if the
      * provided type is NONE or unknown.
      */
-    bump(what) {
+    bump(what, initial_development = true) {
+        if (!initial_development && this.major <= 0) {
+            // Enforce version 1.0.0 in case we are no longer in initial
+            // development and the current major version is 0.
+            //
+            // NOTE: this will enforce a version bump (also for non-bumping commits)
+            return new SemVer({
+                major: 1,
+                minor: 0,
+                patch: 0,
+                prefix: this.prefix,
+            });
+        }
         switch (what) {
             case SemVerType.MAJOR:
+                if (initial_development && this.major <= 0) {
+                    // Bumping major version during initial development is prohibited,
+                    // bump the minor version instead.
+                    return this.next_minor();
+                }
                 return this.next_major();
             case SemVerType.MINOR:
                 return this.next_minor();

--- a/dist/cli/index.js
+++ b/dist/cli/index.js
@@ -6138,7 +6138,7 @@ class SemVer {
         }
         this._build = build_metadata;
     }
-    static from_string(version) {
+    static fromString(version) {
         const match = SEMVER_RE.exec(version);
         if (match != null && match.groups != null) {
             return new SemVer({
@@ -6152,12 +6152,12 @@ class SemVer {
         }
         return null;
     }
-    to_string() {
+    toString() {
         const prerelease = this.prerelease ? `-${this.prerelease}` : "";
         const build = this.build ? `+${this.build}` : "";
         return `${this.prefix}${this.major}.${this.minor}.${this.patch}${prerelease}${build}`;
     }
-    next_major() {
+    nextMajor() {
         return new SemVer({
             major: this.major + 1,
             minor: 0,
@@ -6165,7 +6165,7 @@ class SemVer {
             prefix: this.prefix,
         });
     }
-    next_minor() {
+    nextMinor() {
         return new SemVer({
             major: this.major,
             minor: this.minor + 1,
@@ -6173,7 +6173,7 @@ class SemVer {
             prefix: this.prefix,
         });
     }
-    next_patch() {
+    nextPatch() {
         if (this.prerelease !== "") {
             return new SemVer({
                 major: this.major,
@@ -6211,13 +6211,13 @@ class SemVer {
                 if (initial_development && this.major <= 0) {
                     // Bumping major version during initial development is prohibited,
                     // bump the minor version instead.
-                    return this.next_minor();
+                    return this.nextMinor();
                 }
-                return this.next_major();
+                return this.nextMajor();
             case SemVerType.MINOR:
-                return this.next_minor();
+                return this.nextMinor();
             case SemVerType.PATCH:
-                return this.next_patch();
+                return this.nextPatch();
             default:
                 return null;
         }

--- a/dist/validate/index.js
+++ b/dist/validate/index.js
@@ -11799,6 +11799,7 @@ const CONFIG_ITEMS = [
     "tags",
     "disable",
     "allowed-branches",
+    "initial-development",
 ];
 /**
  * This function takes two values and throws when their types don't match.
@@ -11820,8 +11821,9 @@ class Configuration {
      * Constructs a Configuration parameters from file
      */
     constructor(config_path = DEFAULT_CONFIGURATION_FILE) {
-        this.max_subject_length = 80;
         this.allowed_branches = ".*";
+        this.initial_development = true;
+        this.max_subject_length = 80;
         this.tags = DEFAULT_ACCEPTED_TAGS;
         this.rules = new Map();
         // Enable all rules by default
@@ -11947,6 +11949,17 @@ class Configuration {
                     }
                     else {
                         throw new Error(`Incorrect type '${typeof data[key]}' for '${key}', must be '${typeof this.allowed_branches}'!`);
+                    }
+                    break;
+                case "initial-development":
+                    /* Example YAML
+                     *   initial-development: true
+                     */
+                    if (typeof data[key] === "boolean") {
+                        this.initial_development = data[key];
+                    }
+                    else {
+                        throw new Error(`Incorrect type '${typeof data[key]}' for '${key}', must be '${typeof this.initial_development}'!`);
                     }
                     break;
             }
@@ -13069,7 +13082,7 @@ var SemVerType;
     SemVerType[SemVerType["MAJOR"] = 3] = "MAJOR";
 })(SemVerType = exports.SemVerType || (exports.SemVerType = {}));
 class SemVer {
-    constructor(major, minor, patch, prerelease, build, prefix) {
+    constructor({ major, minor, patch, prerelease = "", build = "", prefix = "", }) {
         this.major = major;
         this.minor = minor;
         this.patch = patch;
@@ -13093,7 +13106,14 @@ class SemVer {
     static from_string(version) {
         const match = SEMVER_RE.exec(version);
         if (match != null && match.groups != null) {
-            return new SemVer(+match.groups.major, +match.groups.minor, +match.groups.patch, match.groups.prerelease || "", match.groups.build || "", match.groups.prefix || "");
+            return new SemVer({
+                major: +match.groups.major,
+                minor: +match.groups.minor,
+                patch: +match.groups.patch,
+                prerelease: match.groups.prerelease || "",
+                build: match.groups.build || "",
+                prefix: match.groups.prefix || "",
+            });
         }
         return null;
     }
@@ -13103,24 +13123,61 @@ class SemVer {
         return `${this.prefix}${this.major}.${this.minor}.${this.patch}${prerelease}${build}`;
     }
     next_major() {
-        return new SemVer(this.major + 1, 0, 0, "", "", this.prefix);
+        return new SemVer({
+            major: this.major + 1,
+            minor: 0,
+            patch: 0,
+            prefix: this.prefix,
+        });
     }
     next_minor() {
-        return new SemVer(this.major, this.minor + 1, 0, "", "", this.prefix);
+        return new SemVer({
+            major: this.major,
+            minor: this.minor + 1,
+            patch: 0,
+            prefix: this.prefix,
+        });
     }
     next_patch() {
         if (this.prerelease !== "") {
-            return new SemVer(this.major, this.minor, this.patch, "", "", this.prefix);
+            return new SemVer({
+                major: this.major,
+                minor: this.minor,
+                patch: this.patch,
+                prefix: this.prefix,
+            });
         }
-        return new SemVer(this.major, this.minor, this.patch + 1, "", "", this.prefix);
+        return new SemVer({
+            major: this.major,
+            minor: this.minor,
+            patch: this.patch + 1,
+            prefix: this.prefix,
+        });
     }
     /**
      * Returns a new SemVer object bumped by the provided bump type, or `null` if the
      * provided type is NONE or unknown.
      */
-    bump(what) {
+    bump(what, initial_development = true) {
+        if (!initial_development && this.major <= 0) {
+            // Enforce version 1.0.0 in case we are no longer in initial
+            // development and the current major version is 0.
+            //
+            // NOTE: this will enforce a version bump (also for non-bumping commits)
+            return new SemVer({
+                major: 1,
+                minor: 0,
+                patch: 0,
+                prefix: this.prefix,
+            });
+        }
         switch (what) {
             case SemVerType.MAJOR:
+                if (initial_development && this.major <= 0) {
+                    // Bumping major version during initial development is prohibited,
+                    // bump the minor version instead.
+                    return this.next_minor();
+                }
                 return this.next_major();
             case SemVerType.MINOR:
                 return this.next_minor();

--- a/dist/validate/index.js
+++ b/dist/validate/index.js
@@ -13103,7 +13103,7 @@ class SemVer {
         }
         this._build = build_metadata;
     }
-    static from_string(version) {
+    static fromString(version) {
         const match = SEMVER_RE.exec(version);
         if (match != null && match.groups != null) {
             return new SemVer({
@@ -13117,12 +13117,12 @@ class SemVer {
         }
         return null;
     }
-    to_string() {
+    toString() {
         const prerelease = this.prerelease ? `-${this.prerelease}` : "";
         const build = this.build ? `+${this.build}` : "";
         return `${this.prefix}${this.major}.${this.minor}.${this.patch}${prerelease}${build}`;
     }
-    next_major() {
+    nextMajor() {
         return new SemVer({
             major: this.major + 1,
             minor: 0,
@@ -13130,7 +13130,7 @@ class SemVer {
             prefix: this.prefix,
         });
     }
-    next_minor() {
+    nextMinor() {
         return new SemVer({
             major: this.major,
             minor: this.minor + 1,
@@ -13138,7 +13138,7 @@ class SemVer {
             prefix: this.prefix,
         });
     }
-    next_patch() {
+    nextPatch() {
         if (this.prerelease !== "") {
             return new SemVer({
                 major: this.major,
@@ -13176,13 +13176,13 @@ class SemVer {
                 if (initial_development && this.major <= 0) {
                     // Bumping major version during initial development is prohibited,
                     // bump the minor version instead.
-                    return this.next_minor();
+                    return this.nextMinor();
                 }
-                return this.next_major();
+                return this.nextMajor();
             case SemVerType.MINOR:
-                return this.next_minor();
+                return this.nextMinor();
             case SemVerType.PATCH:
-                return this.next_patch();
+                return this.nextPatch();
             default:
                 return null;
         }

--- a/src/actions/bump.ts
+++ b/src/actions/bump.ts
@@ -99,7 +99,8 @@ async function run(): Promise<void> {
 
     core.startGroup("🔍 Determining bump");
     const nextVersion: SemVer | null = bumpInfo.foundVersion.bump(
-      bumpInfo.requiredBump
+      bumpInfo.requiredBump,
+      config.initial_development
     );
     if (nextVersion) {
       // Assign Build Metadata

--- a/src/actions/bump.ts
+++ b/src/actions/bump.ts
@@ -91,7 +91,7 @@ async function run(): Promise<void> {
       core.endGroup();
       return;
     } else {
-      const currentVersion = bumpInfo.foundVersion.to_string();
+      const currentVersion = bumpInfo.foundVersion.toString();
       core.info(`ℹ️ Found SemVer tag: ${currentVersion}`);
       core.setOutput("current-version", currentVersion);
     }
@@ -109,7 +109,7 @@ async function run(): Promise<void> {
         nextVersion.build = build_metadata;
       }
 
-      const nv = nextVersion.to_string();
+      const nv = nextVersion.toString();
       core.info(`ℹ️ Next version: ${nv}`);
       core.setOutput("next-version", nv);
       core.endGroup();

--- a/src/actions/bump.ts
+++ b/src/actions/bump.ts
@@ -102,6 +102,15 @@ async function run(): Promise<void> {
       bumpInfo.requiredBump,
       config.initial_development
     );
+
+    if (bumpInfo.foundVersion.major <= 0) {
+      core.warning(
+        config.initial_development
+          ? "This repository is under 'initial development'; breaking changes will bump the `MINOR` version."
+          : "Enforcing version `1.0.0` as we are no longer in `initial development`."
+      );
+    }
+
     if (nextVersion) {
       // Assign Build Metadata
       const build_metadata = core.getInput("build-metadata");

--- a/src/bump.ts
+++ b/src/bump.ts
@@ -58,7 +58,7 @@ function getSemVerIfMatches(
       core.debug(`Tag '${tag}' on commit '${commit.slice(0, 6)}' ${message}`);
     };
     // If provided, make sure that the prefix matches as well
-    const sv: SemVer | null = SemVer.from_string(tagName);
+    const sv: SemVer | null = SemVer.fromString(tagName);
     if (sv) {
       // Asterisk is a special case, meaning 'any prefix'
       if (sv.prefix === prefix || prefix === "*") {

--- a/src/changelog.ts
+++ b/src/changelog.ts
@@ -152,9 +152,9 @@ export async function generateChangelog(
     }
   }
 
-  const diff_range = `${bump.foundVersion.to_string()}...${bump.foundVersion
+  const diff_range = `${bump.foundVersion.toString()}...${bump.foundVersion
     .bump(bump.requiredBump)
-    ?.to_string()}`;
+    ?.toString()}`;
   changelog_formatted += `\n\n*Diff since last release: [${diff_range}](https://github.com/${owner}/${repo}/compare/${diff_range})*`;
 
   return changelog_formatted;

--- a/src/config.ts
+++ b/src/config.ts
@@ -67,6 +67,7 @@ const CONFIG_ITEMS = [
   "tags",
   "disable",
   "allowed-branches",
+  "initial-development",
 ];
 
 /**
@@ -90,8 +91,9 @@ function verifyTypeMatches(
  * Configuration (from file)
  */
 export class Configuration {
-  max_subject_length = 80;
   allowed_branches = ".*";
+  initial_development = true;
+  max_subject_length = 80;
   tags: IConfigurationRules = DEFAULT_ACCEPTED_TAGS;
   rules: Map<string, IRuleConfigItem> = new Map<string, IRuleConfigItem>();
 
@@ -222,6 +224,21 @@ export class Configuration {
               `Incorrect type '${typeof data[
                 key
               ]}' for '${key}', must be '${typeof this.allowed_branches}'!`
+            );
+          }
+          break;
+
+        case "initial-development":
+          /* Example YAML
+           *   initial-development: true
+           */
+          if (typeof data[key] === "boolean") {
+            this.initial_development = data[key];
+          } else {
+            throw new Error(
+              `Incorrect type '${typeof data[
+                key
+              ]}' for '${key}', must be '${typeof this.initial_development}'!`
             );
           }
           break;

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -47,3 +47,12 @@ export interface IConfiguration {
   tags: IConfigurationRules;
   "allowed-branches": string;
 }
+
+export interface ISemVer {
+  major: number;
+  minor: number;
+  patch: number;
+  prerelease?: string;
+  prefix?: string;
+  build?: string;
+}

--- a/src/semver.ts
+++ b/src/semver.ts
@@ -82,7 +82,7 @@ export class SemVer {
     this._build = build_metadata;
   }
 
-  static from_string(version: string): SemVer | null {
+  static fromString(version: string): SemVer | null {
     const match = SEMVER_RE.exec(version);
     if (match != null && match.groups != null) {
       return new SemVer({
@@ -97,14 +97,14 @@ export class SemVer {
     return null;
   }
 
-  to_string(): string {
+  toString(): string {
     const prerelease = this.prerelease ? `-${this.prerelease}` : "";
     const build = this.build ? `+${this.build}` : "";
 
     return `${this.prefix}${this.major}.${this.minor}.${this.patch}${prerelease}${build}`;
   }
 
-  next_major(): SemVer {
+  nextMajor(): SemVer {
     return new SemVer({
       major: this.major + 1,
       minor: 0,
@@ -113,7 +113,7 @@ export class SemVer {
     });
   }
 
-  next_minor(): SemVer {
+  nextMinor(): SemVer {
     return new SemVer({
       major: this.major,
       minor: this.minor + 1,
@@ -122,7 +122,7 @@ export class SemVer {
     });
   }
 
-  next_patch(): SemVer {
+  nextPatch(): SemVer {
     if (this.prerelease !== "") {
       return new SemVer({
         major: this.major,
@@ -162,13 +162,13 @@ export class SemVer {
         if (initial_development && this.major <= 0) {
           // Bumping major version during initial development is prohibited,
           // bump the minor version instead.
-          return this.next_minor();
+          return this.nextMinor();
         }
-        return this.next_major();
+        return this.nextMajor();
       case SemVerType.MINOR:
-        return this.next_minor();
+        return this.nextMinor();
       case SemVerType.PATCH:
-        return this.next_patch();
+        return this.nextPatch();
       default:
         return null;
     }

--- a/test/changelog.test.ts
+++ b/test/changelog.test.ts
@@ -45,7 +45,7 @@ describe("Generate Changelog", () => {
 
   test("All types of changes", async () => {
     const bump: IVersionBumpTypeAndMessages = {
-      foundVersion: new SemVer(1, 0, 0, "", "", ""),
+      foundVersion: new SemVer({ major: 1, minor: 0, patch: 0 }),
       requiredBump: SemVerType.MINOR,
       messages: [
         new ConventionalCommitMessage("feat!: breaks the API"),
@@ -75,7 +75,7 @@ describe("Generate Changelog", () => {
 
   test("Missing PR reference", async () => {
     const bump: IVersionBumpTypeAndMessages = {
-      foundVersion: new SemVer(1, 0, 0, "", "", ""),
+      foundVersion: new SemVer({ major: 1, minor: 0, patch: 0 }),
       requiredBump: SemVerType.MINOR,
       messages: [
         new ConventionalCommitMessage(
@@ -99,7 +99,7 @@ describe("Generate Changelog", () => {
 
   test("Contains PR reference", async () => {
     const bump: IVersionBumpTypeAndMessages = {
-      foundVersion: new SemVer(1, 0, 0, "", "", ""),
+      foundVersion: new SemVer({ major: 1, minor: 0, patch: 0 }),
       requiredBump: SemVerType.MINOR,
       messages: [
         new ConventionalCommitMessage(
@@ -123,7 +123,7 @@ describe("Generate Changelog", () => {
 
   test("Issue reference", async () => {
     const bump: IVersionBumpTypeAndMessages = {
-      foundVersion: new SemVer(1, 0, 0, "", "", ""),
+      foundVersion: new SemVer({ major: 1, minor: 0, patch: 0 }),
       requiredBump: SemVerType.MINOR,
       messages: [
         new ConventionalCommitMessage(

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -219,4 +219,16 @@ describe("Configurable options", () => {
       }
     );
   });
+
+  test("Default initial development value", () => {
+    withConfig("", () => {
+      expect(new Configuration().initial_development).toEqual(true);
+    });
+  });
+
+  test("Disable initial development", () => {
+    withConfig("initial-development: false", () => {
+      expect(new Configuration().initial_development).toEqual(false);
+    });
+  });
 });

--- a/test/semver.test.ts
+++ b/test/semver.test.ts
@@ -21,27 +21,34 @@ import { SemVer, SemVerType } from "../src/semver";
 describe("Semantic Version parsing correct input", () => {
   test("Full", () => {
     expect(SemVer.from_string("some-prefix-1.2.3-4+5")).toStrictEqual(
-      new SemVer(1, 2, 3, "4", "5", "some-prefix-")
+      new SemVer({
+        major: 1,
+        minor: 2,
+        patch: 3,
+        prerelease: "4",
+        build: "5",
+        prefix: "some-prefix-",
+      })
     );
   });
   test("No prefix", () => {
     expect(SemVer.from_string("1.2.3-4+5")).toStrictEqual(
-      new SemVer(1, 2, 3, "4", "5", "")
+      new SemVer({ major: 1, minor: 2, patch: 3, prerelease: "4", build: "5" })
     );
   });
   test("No prefix and build", () => {
     expect(SemVer.from_string("1.2.3-4")).toStrictEqual(
-      new SemVer(1, 2, 3, "4", "", "")
+      new SemVer({ major: 1, minor: 2, patch: 3, prerelease: "4" })
     );
   });
   test("No prefix and prerelease", () => {
     expect(SemVer.from_string("1.2.3+5")).toStrictEqual(
-      new SemVer(1, 2, 3, "", "5", "")
+      new SemVer({ major: 1, minor: 2, patch: 3, build: "5" })
     );
   });
   test("No prerelease and build", () => {
     expect(SemVer.from_string("v1.2.3")).toStrictEqual(
-      new SemVer(1, 2, 3, "", "", "v")
+      new SemVer({ major: 1, minor: 2, patch: 3, prefix: "v" })
     );
   });
 });
@@ -90,22 +97,83 @@ describe("Semantic Version bumping by type", () => {
   test("Bump major", () => {
     expect(
       SemVer.from_string("v1.2.3-4")?.bump(SemVerType.MAJOR)
-    ).toStrictEqual(new SemVer(2, 0, 0, "", "", "v"));
+    ).toStrictEqual(new SemVer({ major: 2, minor: 0, patch: 0, prefix: "v" }));
   });
   test("Bump minor", () => {
     expect(
       SemVer.from_string("v1.2.3-4")?.bump(SemVerType.MINOR)
-    ).toStrictEqual(new SemVer(1, 3, 0, "", "", "v"));
+    ).toStrictEqual(new SemVer({ major: 1, minor: 3, patch: 0, prefix: "v" }));
   });
   test("Bump patch on prerelease", () => {
     expect(
       SemVer.from_string("v1.2.3-4")?.bump(SemVerType.PATCH)
-    ).toStrictEqual(new SemVer(1, 2, 3, "", "", "v"));
+    ).toStrictEqual(new SemVer({ major: 1, minor: 2, patch: 3, prefix: "v" }));
   });
   test("Bump patch", () => {
     expect(SemVer.from_string("v1.2.3")?.bump(SemVerType.PATCH)).toStrictEqual(
-      new SemVer(1, 2, 4, "", "", "v")
+      new SemVer({ major: 1, minor: 2, patch: 4, prefix: "v" })
     );
+  });
+  test("No bump", () => {
+    expect(SemVer.from_string("v1.2.3")?.bump(SemVerType.NONE)).toStrictEqual(
+      null
+    );
+  });
+});
+
+describe("Semantic Version bumping by type (initial development)", () => {
+  test("Bump major", () => {
+    expect(
+      SemVer.from_string("v0.2.3-4")?.bump(SemVerType.MAJOR)
+    ).toStrictEqual(new SemVer({ major: 0, minor: 3, patch: 0, prefix: "v" }));
+  });
+  test("Bump minor", () => {
+    expect(
+      SemVer.from_string("v0.2.3-4")?.bump(SemVerType.MINOR)
+    ).toStrictEqual(new SemVer({ major: 0, minor: 3, patch: 0, prefix: "v" }));
+  });
+  test("Bump patch on prerelease", () => {
+    expect(
+      SemVer.from_string("v0.2.3-4")?.bump(SemVerType.PATCH)
+    ).toStrictEqual(new SemVer({ major: 0, minor: 2, patch: 3, prefix: "v" }));
+  });
+  test("Bump patch", () => {
+    expect(SemVer.from_string("v0.2.3")?.bump(SemVerType.PATCH)).toStrictEqual(
+      new SemVer({ major: 0, minor: 2, patch: 4, prefix: "v" })
+    );
+  });
+  test("No bump", () => {
+    expect(SemVer.from_string("v0.2.3")?.bump(SemVerType.NONE)).toStrictEqual(
+      null
+    );
+  });
+});
+
+describe("Semantic Version bumping by type (end of initial development)", () => {
+  test("Bump major", () => {
+    expect(
+      SemVer.from_string("v0.2.3-4")?.bump(SemVerType.MAJOR, false)
+    ).toStrictEqual(new SemVer({ major: 1, minor: 0, patch: 0, prefix: "v" }));
+  });
+  test("Bump minor", () => {
+    expect(
+      SemVer.from_string("v0.2.3-4")?.bump(SemVerType.MINOR, false)
+    ).toStrictEqual(new SemVer({ major: 1, minor: 0, patch: 0, prefix: "v" }));
+  });
+  test("Bump patch on prerelease", () => {
+    expect(
+      SemVer.from_string("v0.2.3-4")?.bump(SemVerType.PATCH, false)
+    ).toStrictEqual(new SemVer({ major: 1, minor: 0, patch: 0, prefix: "v" }));
+  });
+  test("Bump patch", () => {
+    expect(
+      SemVer.from_string("v0.2.3")?.bump(SemVerType.PATCH, false)
+    ).toStrictEqual(new SemVer({ major: 1, minor: 0, patch: 0, prefix: "v" }));
+  });
+  test("No bump", () => {
+    expect(
+      SemVer.from_string("v0.2.3")?.bump(SemVerType.NONE, false)
+    ).toStrictEqual(new SemVer({ major: 1, minor: 0, patch: 0, prefix: "v" }));
   });
 });
 
@@ -142,22 +210,37 @@ describe("Semantic Version ordering", () => {
 describe("Build metadata", () => {
   test("Missing build metadata", () => {
     expect(() => {
-      new SemVer(1, 2, 3, "4", "", "5");
+      new SemVer({ major: 1, minor: 2, patch: 3 });
     }).not.toThrow(Error);
   });
   test("Valid build metadata", () => {
     expect(() => {
-      new SemVer(1, 2, 3, "4", "identifier-1.identifier-2", "5");
+      new SemVer({
+        major: 1,
+        minor: 2,
+        patch: 3,
+        build: "identifier-1.identifier-2",
+      });
     }).not.toThrow(Error);
   });
   test("Invalid build metadata", () => {
     expect(() => {
-      new SemVer(1, 2, 3, "4", "identifier-1.identifier-2&wrong", "5");
+      new SemVer({
+        major: 1,
+        minor: 2,
+        patch: 3,
+        build: "identifier-1.identifier-2&wrong",
+      });
     }).toThrow(Error);
   });
   test("Empty indentifier in build metadata", () => {
     expect(() => {
-      new SemVer(1, 2, 3, "4", "identifier-1..identifier-2", "5");
+      new SemVer({
+        major: 1,
+        minor: 2,
+        patch: 3,
+        build: "identifier-1..identifier-2",
+      });
     }).toThrow(Error);
   });
 });

--- a/test/semver.test.ts
+++ b/test/semver.test.ts
@@ -20,7 +20,7 @@ import { SemVer, SemVerType } from "../src/semver";
 
 describe("Semantic Version parsing correct input", () => {
   test("Full", () => {
-    expect(SemVer.from_string("some-prefix-1.2.3-4+5")).toStrictEqual(
+    expect(SemVer.fromString("some-prefix-1.2.3-4+5")).toStrictEqual(
       new SemVer({
         major: 1,
         minor: 2,
@@ -32,22 +32,22 @@ describe("Semantic Version parsing correct input", () => {
     );
   });
   test("No prefix", () => {
-    expect(SemVer.from_string("1.2.3-4+5")).toStrictEqual(
+    expect(SemVer.fromString("1.2.3-4+5")).toStrictEqual(
       new SemVer({ major: 1, minor: 2, patch: 3, prerelease: "4", build: "5" })
     );
   });
   test("No prefix and build", () => {
-    expect(SemVer.from_string("1.2.3-4")).toStrictEqual(
+    expect(SemVer.fromString("1.2.3-4")).toStrictEqual(
       new SemVer({ major: 1, minor: 2, patch: 3, prerelease: "4" })
     );
   });
   test("No prefix and prerelease", () => {
-    expect(SemVer.from_string("1.2.3+5")).toStrictEqual(
+    expect(SemVer.fromString("1.2.3+5")).toStrictEqual(
       new SemVer({ major: 1, minor: 2, patch: 3, build: "5" })
     );
   });
   test("No prerelease and build", () => {
-    expect(SemVer.from_string("v1.2.3")).toStrictEqual(
+    expect(SemVer.fromString("v1.2.3")).toStrictEqual(
       new SemVer({ major: 1, minor: 2, patch: 3, prefix: "v" })
     );
   });
@@ -56,66 +56,66 @@ describe("Semantic Version parsing correct input", () => {
 describe("Semantic Version lossless stringification", () => {
   test("All fields", () => {
     const input = "version1.2.3-5+678";
-    expect(SemVer.from_string(input)?.to_string()).toEqual(input);
+    expect(SemVer.fromString(input)?.toString()).toEqual(input);
   });
   test("Major, minor, patch", () => {
     const input = "1.2.3";
-    expect(SemVer.from_string(input)?.to_string()).toEqual(input);
+    expect(SemVer.fromString(input)?.toString()).toEqual(input);
   });
   test("Major, minor, patch, build", () => {
     const input = "1.2.3+5";
-    expect(SemVer.from_string(input)?.to_string()).toEqual(input);
+    expect(SemVer.fromString(input)?.toString()).toEqual(input);
   });
   test("Prefix, Major, minor, patch, prerelease", () => {
     const input = "version-1.2.3-prerelease";
-    expect(SemVer.from_string(input)?.to_string()).toEqual(input);
+    expect(SemVer.fromString(input)?.toString()).toEqual(input);
   });
 });
 
 describe("Semantic Version parsing incorrect input", () => {
   test("Random non-semantic version", () => {
-    expect(SemVer.from_string("version_1-2-3")).toBeNull();
+    expect(SemVer.fromString("version_1-2-3")).toBeNull();
   });
   test("Invalid characters in prefix", () => {
-    expect(SemVer.from_string("version_1.2.3-4")).toBeNull();
+    expect(SemVer.fromString("version_1.2.3-4")).toBeNull();
   });
   test("Only major and minor", () => {
-    expect(SemVer.from_string("1.2-beta.1")).toBeNull();
+    expect(SemVer.fromString("1.2-beta.1")).toBeNull();
   });
   test("Empty prerelease", () => {
-    expect(SemVer.from_string("1.2.3-")).toBeNull();
+    expect(SemVer.fromString("1.2.3-")).toBeNull();
   });
   test("Empty build", () => {
-    expect(SemVer.from_string("1.2.3-1.2+")).toBeNull();
+    expect(SemVer.fromString("1.2.3-1.2+")).toBeNull();
   });
   test("Empty prerelease and build", () => {
-    expect(SemVer.from_string("1.2.3-+")).toBeNull();
+    expect(SemVer.fromString("1.2.3-+")).toBeNull();
   });
 });
 
 describe("Semantic Version bumping by type", () => {
   test("Bump major", () => {
-    expect(
-      SemVer.from_string("v1.2.3-4")?.bump(SemVerType.MAJOR)
-    ).toStrictEqual(new SemVer({ major: 2, minor: 0, patch: 0, prefix: "v" }));
+    expect(SemVer.fromString("v1.2.3-4")?.bump(SemVerType.MAJOR)).toStrictEqual(
+      new SemVer({ major: 2, minor: 0, patch: 0, prefix: "v" })
+    );
   });
   test("Bump minor", () => {
-    expect(
-      SemVer.from_string("v1.2.3-4")?.bump(SemVerType.MINOR)
-    ).toStrictEqual(new SemVer({ major: 1, minor: 3, patch: 0, prefix: "v" }));
+    expect(SemVer.fromString("v1.2.3-4")?.bump(SemVerType.MINOR)).toStrictEqual(
+      new SemVer({ major: 1, minor: 3, patch: 0, prefix: "v" })
+    );
   });
   test("Bump patch on prerelease", () => {
-    expect(
-      SemVer.from_string("v1.2.3-4")?.bump(SemVerType.PATCH)
-    ).toStrictEqual(new SemVer({ major: 1, minor: 2, patch: 3, prefix: "v" }));
+    expect(SemVer.fromString("v1.2.3-4")?.bump(SemVerType.PATCH)).toStrictEqual(
+      new SemVer({ major: 1, minor: 2, patch: 3, prefix: "v" })
+    );
   });
   test("Bump patch", () => {
-    expect(SemVer.from_string("v1.2.3")?.bump(SemVerType.PATCH)).toStrictEqual(
+    expect(SemVer.fromString("v1.2.3")?.bump(SemVerType.PATCH)).toStrictEqual(
       new SemVer({ major: 1, minor: 2, patch: 4, prefix: "v" })
     );
   });
   test("No bump", () => {
-    expect(SemVer.from_string("v1.2.3")?.bump(SemVerType.NONE)).toStrictEqual(
+    expect(SemVer.fromString("v1.2.3")?.bump(SemVerType.NONE)).toStrictEqual(
       null
     );
   });
@@ -123,27 +123,27 @@ describe("Semantic Version bumping by type", () => {
 
 describe("Semantic Version bumping by type (initial development)", () => {
   test("Bump major", () => {
-    expect(
-      SemVer.from_string("v0.2.3-4")?.bump(SemVerType.MAJOR)
-    ).toStrictEqual(new SemVer({ major: 0, minor: 3, patch: 0, prefix: "v" }));
+    expect(SemVer.fromString("v0.2.3-4")?.bump(SemVerType.MAJOR)).toStrictEqual(
+      new SemVer({ major: 0, minor: 3, patch: 0, prefix: "v" })
+    );
   });
   test("Bump minor", () => {
-    expect(
-      SemVer.from_string("v0.2.3-4")?.bump(SemVerType.MINOR)
-    ).toStrictEqual(new SemVer({ major: 0, minor: 3, patch: 0, prefix: "v" }));
+    expect(SemVer.fromString("v0.2.3-4")?.bump(SemVerType.MINOR)).toStrictEqual(
+      new SemVer({ major: 0, minor: 3, patch: 0, prefix: "v" })
+    );
   });
   test("Bump patch on prerelease", () => {
-    expect(
-      SemVer.from_string("v0.2.3-4")?.bump(SemVerType.PATCH)
-    ).toStrictEqual(new SemVer({ major: 0, minor: 2, patch: 3, prefix: "v" }));
+    expect(SemVer.fromString("v0.2.3-4")?.bump(SemVerType.PATCH)).toStrictEqual(
+      new SemVer({ major: 0, minor: 2, patch: 3, prefix: "v" })
+    );
   });
   test("Bump patch", () => {
-    expect(SemVer.from_string("v0.2.3")?.bump(SemVerType.PATCH)).toStrictEqual(
+    expect(SemVer.fromString("v0.2.3")?.bump(SemVerType.PATCH)).toStrictEqual(
       new SemVer({ major: 0, minor: 2, patch: 4, prefix: "v" })
     );
   });
   test("No bump", () => {
-    expect(SemVer.from_string("v0.2.3")?.bump(SemVerType.NONE)).toStrictEqual(
+    expect(SemVer.fromString("v0.2.3")?.bump(SemVerType.NONE)).toStrictEqual(
       null
     );
   });
@@ -152,27 +152,27 @@ describe("Semantic Version bumping by type (initial development)", () => {
 describe("Semantic Version bumping by type (end of initial development)", () => {
   test("Bump major", () => {
     expect(
-      SemVer.from_string("v0.2.3-4")?.bump(SemVerType.MAJOR, false)
+      SemVer.fromString("v0.2.3-4")?.bump(SemVerType.MAJOR, false)
     ).toStrictEqual(new SemVer({ major: 1, minor: 0, patch: 0, prefix: "v" }));
   });
   test("Bump minor", () => {
     expect(
-      SemVer.from_string("v0.2.3-4")?.bump(SemVerType.MINOR, false)
+      SemVer.fromString("v0.2.3-4")?.bump(SemVerType.MINOR, false)
     ).toStrictEqual(new SemVer({ major: 1, minor: 0, patch: 0, prefix: "v" }));
   });
   test("Bump patch on prerelease", () => {
     expect(
-      SemVer.from_string("v0.2.3-4")?.bump(SemVerType.PATCH, false)
+      SemVer.fromString("v0.2.3-4")?.bump(SemVerType.PATCH, false)
     ).toStrictEqual(new SemVer({ major: 1, minor: 0, patch: 0, prefix: "v" }));
   });
   test("Bump patch", () => {
     expect(
-      SemVer.from_string("v0.2.3")?.bump(SemVerType.PATCH, false)
+      SemVer.fromString("v0.2.3")?.bump(SemVerType.PATCH, false)
     ).toStrictEqual(new SemVer({ major: 1, minor: 0, patch: 0, prefix: "v" }));
   });
   test("No bump", () => {
     expect(
-      SemVer.from_string("v0.2.3")?.bump(SemVerType.NONE, false)
+      SemVer.fromString("v0.2.3")?.bump(SemVerType.NONE, false)
     ).toStrictEqual(new SemVer({ major: 1, minor: 0, patch: 0, prefix: "v" }));
   });
 });
@@ -180,29 +180,29 @@ describe("Semantic Version bumping by type (end of initial development)", () => 
 describe("Semantic Version ordering", () => {
   test("Equality", () => {
     expect(
-      SemVer.from_string("v1.2.3")?.equals(SemVer.from_string("v1.2.3")!)
+      SemVer.fromString("v1.2.3")?.equals(SemVer.fromString("v1.2.3")!)
     ).toBe(true);
   });
   test("Equality with different prefix", () => {
     expect(
-      SemVer.from_string("prefix-one-1.2.3")?.equals(
-        SemVer.from_string("prefix-two-1.2.3")!
+      SemVer.fromString("prefix-one-1.2.3")?.equals(
+        SemVer.fromString("prefix-two-1.2.3")!
       )
     ).toBe(true);
   });
   test("Minor less than major", () => {
     expect(
-      SemVer.from_string("v1.3.3")?.lessThan(SemVer.from_string("v2.2.3")!)
+      SemVer.fromString("v1.3.3")?.lessThan(SemVer.fromString("v2.2.3")!)
     ).toBe(true);
   });
   test("Patch less than minor", () => {
     expect(
-      SemVer.from_string("v1.2.4")?.lessThan(SemVer.from_string("v1.3.3")!)
+      SemVer.fromString("v1.2.4")?.lessThan(SemVer.fromString("v1.3.3")!)
     ).toBe(true);
   });
   test("Prerelease less than patch", () => {
     expect(
-      SemVer.from_string("v1.2.3-4")?.lessThan(SemVer.from_string("v1.2.3")!)
+      SemVer.fromString("v1.2.3-4")?.lessThan(SemVer.fromString("v1.2.3")!)
     ).toBe(true);
   });
 });


### PR DESCRIPTION
During initial development, you should avoid bumping the `MAJOR` version. By default, we will bump the `MINOR` version for breaking changes in case:
- The current `MAJOR`-version is `0`
- **AND** the `initial-development` configuration parameter is `true` (default value)

We will automatically bump the version to `1.0.0` when:
- The current `MAJOR`-version is `0`
- **AND** the `initial-development` configuration parameter is `false`

> NOTE: This behavior also applies to non-bumping commits (ie. `chore:`, `ci:`)