### PR TITLE
fix(bump): use  GitHub API for fetching tags by date

### DIFF
--- a/src/actions/bump.ts
+++ b/src/actions/bump.ts
@@ -25,6 +25,7 @@ import {
   createRelease,
   createTag,
   getConfig,
+  getLatestTags,
   isPullRequestEvent,
 } from "../github";
 import { IVersionBumpTypeAndMessages } from "../interfaces";

--- a/src/bump.ts
+++ b/src/bump.ts
@@ -18,7 +18,7 @@ import * as core from "@actions/core";
 
 import { Configuration } from "./config";
 
-import { getCommitsSince, getTags } from "./github";
+import { getCommitsSince, getLatestTags } from "./github";
 import { ConventionalCommitMessage } from "./commit";
 import { SemVer, SemVerType } from "./semver";
 import {
@@ -131,14 +131,14 @@ export async function getVersionBumpTypeAndMessages(
   core.debug(`Fetching last ${PAGE_SIZE} tags and commits from ${targetSha}..`);
   const [commits, tags] = await Promise.all([
     getCommitsSince(targetSha, PAGE_SIZE),
-    getTags(PAGE_SIZE),
+    getLatestTags(PAGE_SIZE),
   ]);
   core.debug("Fetch complete");
 
   commit_loop: for (const commit of commits) {
     // Try and match this commit's hash to a tag
     for (const tag of tags) {
-      semVer = getSemVerIfMatches(prefix, tag.name, tag.commit.sha, commit.sha);
+      semVer = getSemVerIfMatches(prefix, tag.name, tag.commitSha, commit.sha);
       if (semVer) {
         break commit_loop;
       }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -56,3 +56,8 @@ export interface ISemVer {
   prefix?: string;
   build?: string;
 }
+
+export interface IGitTag {
+  name: string;
+  commitSha: string;
+}


### PR DESCRIPTION
The REST API call used previously is both not properly documented and did not behave as assumed, leading to failure to resolve the latest tags if the version scheme changed and the total amount of tags in the repo exceeds 100.

We now order explicitly by GitHub's own `TAG_COMMIT_DATE`, which introduces another caveat; the documentation for that order method says:

 > Order refs by underlying commit date if the ref prefix is refs/tags/

No mention of how that is implemented or what Git data it uses under the hood. The phrasing _hints_ that it uses the ref's `committerdate`, which would be invalid for annotated tags, but during testing, it appears to "work fine", which means it probably uses `creatordate` or (more likely) a custom implementation.