### PR TITLE
feat: support grouping changelog entries by scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,7 @@ Commit messages, for example:
 You can configure the content of your Changelog using the `release.y[a]ml` configuration file stored in `.github`, for ex.
 ```yaml
 changelog:
+  group: "scope" # OPTIONAL; allows grouping by Conventional Commit scope
   exclude:
     labels:
       - dependencies
@@ -231,8 +232,7 @@ changelog:
         - "*"
 ```
 
-During generation, each individual conventional commit will associated with the following
-labels:
+During generation, each conventional commit will be associated with the following labels:
 
 | Label | Description |
 | --- | --- |

--- a/README.md
+++ b/README.md
@@ -236,10 +236,11 @@ labels:
 
 | Label | Description |
 | --- | --- |
-| `bump:<version>` | The SemVer version to be bumped by this individual commit |
-| `type:<type>` | Conventional Commit type associated with this commit message |
+| `bump:<version>` | The SemVer version to be bumped by this individual commit     |
+| `type:<type>`    | Conventional Commit type associated with this commit message  |
+| `scope:<scope>`  | Conventional Commit scope associated with this commit message |
 
-> **NOTE**: The `bump:<version>` and `type:<type>` labels set on your Pull Request will be
+> **NOTE**: The `bump:<version>`, `type:<type>` and `scope:<scope>` labels set on your Pull Request will be
 ignored in favor of individual commits
 
 Please refer to the ["Automatically generated release notes"](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes#configuring-automatically-generated-release-notes) documentation for more details

--- a/dist/bump/index.js
+++ b/dist/bump/index.js
@@ -12008,19 +12008,25 @@ function generateChangelog(bump) {
             // * The version bump (`bump:<version>`)
             // * The conventional commit type (`type:<type>`)
             let labels = [bumpLabel, typeLabel];
+            // * The conventional commit scope (`scope:<scope>`)
+            if (commit.message.scope) {
+                const scopeLabel = `scope:${commit.message.scope}`;
+                labels.push(scopeLabel);
+            }
             // We will reuse the labels and author associated with a Pull Request
-            // (with the exception of `bump:<version`) for all commits associated
-            // with the PR.
+            // (with the exception of `bump:<version>` and `scope:<scope>`) for all
+            // commits associated with the PR.
             if (commit.message.hexsha) {
                 const pullRequests = yield (0, github_2.getAssociatedPullRequests)(commit.message.hexsha);
                 if (pullRequests.length > 0) {
                     const pullRequest = pullRequests[0];
                     // Append the labels of the associated Pull Request
-                    // NOTE: we ignore the version bump label on the PR as this is
+                    // NOTE: we ignore the version bump and scope label on the PR as this is
                     //       and instead rely on version bump label associated with this
                     //       commit.
                     labels = labels.concat(pullRequest.labels
-                        .filter(label => !label.name.startsWith("bump:"))
+                        .filter(label => !label.name.startsWith("bump:") &&
+                        !label.name.startsWith("scope:"))
                         .map(label => label.name));
                     // Check if the author of the Pull Request is part of the exclude list
                     if (pullRequest.user &&

--- a/src/changelog.ts
+++ b/src/changelog.ts
@@ -188,9 +188,15 @@ export async function generateChangelog(
     // * The conventional commit type (`type:<type>`)
     let labels: string[] = [bumpLabel, typeLabel];
 
+    // * The conventional commit scope (`scope:<scope>`)
+    if (commit.message.scope) {
+      const scopeLabel = `scope:${commit.message.scope.toLowerCase()}`;
+      labels.push(scopeLabel);
+    }
+
     // We will reuse the labels and author associated with a Pull Request
-    // (with the exception of `bump:<version`) for all commits associated
-    // with the PR.
+    // (with the exception of `bump:<version>` and `scope:<scope>`) for all
+    // commits associated with the PR.
 
     if (commit.message.hexsha) {
       const pullRequests = await getAssociatedPullRequests(
@@ -201,12 +207,16 @@ export async function generateChangelog(
         const pullRequest = pullRequests[0];
 
         // Append the labels of the associated Pull Request
-        // NOTE: we ignore the version bump label on the PR as this is
+        // NOTE: we ignore the version bump and scope label on the PR as this is
         //       and instead rely on version bump label associated with this
         //       commit.
         labels = labels.concat(
           pullRequest.labels
-            .filter(label => !label.name.startsWith("bump:"))
+            .filter(
+              label =>
+                !label.name.startsWith("bump:") &&
+                !label.name.startsWith("scope:")
+            )
             .map(label => label.name)
         );
 

--- a/test/changelog.test.ts
+++ b/test/changelog.test.ts
@@ -312,7 +312,7 @@ describe("Generate Changelog", () => {
       processedCommits: createMessages([
         {
           message:
-            "feat!: add pull request reference\n\nThis is the body\n\nImplements: TEST-123",
+            "feat(Search)!: add pull request reference\n\nThis is the body\n\nImplements: TEST-123",
           sha: "17e57c03317",
         },
         {
@@ -328,8 +328,8 @@ describe("Generate Changelog", () => {
         changelog: {
           categories: [
             {
-              title: "Major Changes",
-              labels: ["bump:major"],
+              title: "Search API",
+              labels: ["scope:search"],
             },
             {
               title: "Documentation",
@@ -344,7 +344,7 @@ describe("Generate Changelog", () => {
     expect(changelog).toEqual(
       dedent(
         `## What's changed
-        ### Major Changes
+        ### Search API
         * Add pull request reference (#123) (TEST-123) [[17e57c](https://github.com/tomtom-international/commisery-action/commit/17e57c03317)]
         ### Documentation
         * Do GitHub things (#123) (#42) [[27e57c](https://github.com/tomtom-international/commisery-action/commit/27e57c03317)]
@@ -354,7 +354,7 @@ describe("Generate Changelog", () => {
       )
     );
   });
-
+  
   afterAll(() => {
     jest.restoreAllMocks();
   });


### PR DESCRIPTION
This Pull Request will allow users to group their Changelog file based on the Conventional Commit scope, i.e.:

## What's changed
### Search
#### New Features
* Added `doIt(...)` interface to do it [[17e57c]()]
* Extended `doIt(...)` to allow for deferred actions [[17e57c]()]
#### Documentation
* Updated Search API documentation [[27e57c]()]
### Internal
#### Bug Fixes
* Very important fix for development tooling [[17e57c]()]
