### PR TITLE
chore: consider all draft releases for updates

### DIFF
--- a/dist/bump/index.js
+++ b/dist/bump/index.js
@@ -11773,7 +11773,6 @@ exports.getVersionBumpTypeAndMessages = getVersionBumpTypeAndMessages;
  * `undefined` otherwise.
  */
 function tryUpdateDraftRelease(cv, changelog, sha) {
-    var _a;
     return __awaiter(this, void 0, void 0, function* () {
         const preStem = cv.prerelease
             ? `-${cv.prerelease.replace(/(.+?)\d.*/, "$1")}`
@@ -11781,7 +11780,7 @@ function tryUpdateDraftRelease(cv, changelog, sha) {
         const baseCurrent = `${cv.prefix}${cv.major}.${cv.minor}.${cv.patch}${preStem}`;
         const nextMajor = `${cv.nextMajor().toString()}${preStem}`;
         const nextMinor = `${cv.nextMinor().toString()}${preStem}`;
-        const latestDraftRelease = (_a = (yield (0, github_1.getRelease)(nextMajor, true))) !== null && _a !== void 0 ? _a : (yield (0, github_1.getRelease)(nextMinor, true));
+        const latestDraftRelease = yield (0, github_1.getRelease)(cv.prefix, true);
         if (!latestDraftRelease)
             return;
         const currentDraftVersion = semver_1.SemVer.fromString(latestDraftRelease.name);
@@ -12152,14 +12151,12 @@ function bumpSdkVer(config, bumpInfo, releaseMode, sdkVerBumpType, headSha, bran
         let cv = semver_1.SemVer.copy(bumpInfo.foundVersion);
         const baseCurrent = `${cv.prefix}${cv.major}.${cv.minor}.${cv.patch}` +
             `${cv.prerelease ? `-${cv.prerelease.replace(/(.+?)\d.*/, "$1")}` : ""}`;
-        // See if we already have a dev (draft) release for the _next_ version.
+        // Get the latest draft release matching our current version's prefix.
         // Don't look at the draft version on a release branch; the current version
         // should always reflect the version to be bumped (as no dev releases are
         // allowed on a release branch)
-        const latestNextMinorDraft = yield (0, github_1.getRelease)(cv.nextMinor().toString(), true);
-        const latestNextMajorDraft = yield (0, github_1.getRelease)(cv.nextMajor().toString(), true);
-        const latestDraft = latestNextMajorDraft !== null && latestNextMajorDraft !== void 0 ? latestNextMajorDraft : latestNextMinorDraft;
-        const latestRelease = yield (0, github_1.getRelease)(baseCurrent, false);
+        const latestDraft = yield (0, github_1.getRelease)(cv.prefix, true);
+        const latestRelease = yield (0, github_1.getRelease)(cv.prefix, false);
         core.info(`Current version: ${cv.toString()}, latest GitHub release draft: ${(_a = latestDraft === null || latestDraft === void 0 ? void 0 : latestDraft.name) !== null && _a !== void 0 ? _a : "NONE"}, latest GitHub release: ${(_b = latestRelease === null || latestRelease === void 0 ? void 0 : latestRelease.name) !== null && _b !== void 0 ? _b : "NONE"}`);
         // `latestRelease` is not used for anything functional at this point
         if (!isReleaseBranch && latestDraft) {
@@ -13226,9 +13223,9 @@ function sortVersionPrereleases(releaseList, nameStartsWith) {
  *
  * Returns an object {id, name}, or `undefined` if no tag was found.
  */
-function getRelease(nameStartsWith, isDraft) {
+function getRelease(prefixMustMatch, isDraft) {
     return __awaiter(this, void 0, void 0, function* () {
-        core.info(`getRelease: finding ${isDraft ? "draft " : ""}release starting with: ${nameStartsWith}`);
+        core.info(`getRelease: finding ${isDraft ? "draft " : ""}release with the prefix: ${prefixMustMatch}`);
         const octo = getOctokit();
         const result = (yield octo.paginate(octo.rest.repos.listReleases, Object.assign({}, github.context.repo))).map(r => ({ isDraft: r.draft, tagName: r.tag_name, id: r.id }));
         core.debug(`getRelease: listReleases returned:\n${JSON.stringify(result)}`);
@@ -13243,7 +13240,7 @@ function getRelease(nameStartsWith, isDraft) {
          */
         const releaseList = result
             .filter(r => r.isDraft === isDraft)
-            .filter(r => r.tagName.startsWith(nameStartsWith))
+            .filter(r => { var _a; return ((_a = semver_1.SemVer.fromString(r.tagName)) === null || _a === void 0 ? void 0 : _a.prefix) === prefixMustMatch; })
             .map(r => ({ id: r.id, name: r.tagName }))
             .sort((lhs, rhs) => semver_1.SemVer.sortSemVer(lhs.name, rhs.name));
         core.debug(`getRelease: sorted list of releases:\n${JSON.stringify(releaseList)}`);

--- a/src/bump.ts
+++ b/src/bump.ts
@@ -233,8 +233,7 @@ async function tryUpdateDraftRelease(
   const baseCurrent = `${cv.prefix}${cv.major}.${cv.minor}.${cv.patch}${preStem}`;
   const nextMajor = `${cv.nextMajor().toString()}${preStem}`;
   const nextMinor = `${cv.nextMinor().toString()}${preStem}`;
-  const latestDraftRelease =
-    (await getRelease(nextMajor, true)) ?? (await getRelease(nextMinor, true));
+  const latestDraftRelease = await getRelease(cv.prefix, true);
   if (!latestDraftRelease) return;
 
   const currentDraftVersion = SemVer.fromString(latestDraftRelease.name);
@@ -710,21 +709,12 @@ export async function bumpSdkVer(
     `${cv.prefix}${cv.major}.${cv.minor}.${cv.patch}` +
     `${cv.prerelease ? `-${cv.prerelease.replace(/(.+?)\d.*/, "$1")}` : ""}`;
 
-  // See if we already have a dev (draft) release for the _next_ version.
+  // Get the latest draft release matching our current version's prefix.
   // Don't look at the draft version on a release branch; the current version
   // should always reflect the version to be bumped (as no dev releases are
   // allowed on a release branch)
-
-  const latestNextMinorDraft = await getRelease(
-    cv.nextMinor().toString(),
-    true
-  );
-  const latestNextMajorDraft = await getRelease(
-    cv.nextMajor().toString(),
-    true
-  );
-  const latestDraft = latestNextMajorDraft ?? latestNextMinorDraft;
-  const latestRelease = await getRelease(baseCurrent, false);
+  const latestDraft = await getRelease(cv.prefix, true);
+  const latestRelease = await getRelease(cv.prefix, false);
   core.info(
     `Current version: ${cv.toString()}, latest GitHub release draft: ${
       latestDraft?.name ?? "NONE"

--- a/src/github.ts
+++ b/src/github.ts
@@ -146,13 +146,13 @@ function sortVersionPrereleases(
  * Returns an object {id, name}, or `undefined` if no tag was found.
  */
 export async function getRelease(
-  nameStartsWith: string,
+  prefixMustMatch: string,
   isDraft: boolean
 ): Promise<{ id: number; name: string } | undefined> {
   core.info(
     `getRelease: finding ${
       isDraft ? "draft " : ""
-    }release starting with: ${nameStartsWith}`
+    }release with the prefix: ${prefixMustMatch}`
   );
   const octo = getOctokit();
 
@@ -176,7 +176,7 @@ export async function getRelease(
 
   const releaseList = result
     .filter(r => r.isDraft === isDraft)
-    .filter(r => r.tagName.startsWith(nameStartsWith))
+    .filter(r => SemVer.fromString(r.tagName)?.prefix === prefixMustMatch)
     .map(r => ({ id: r.id, name: r.tagName }))
     .sort((lhs, rhs) => SemVer.sortSemVer(lhs.name, rhs.name));
 
@@ -273,7 +273,7 @@ export async function getReleaseConfiguration(): Promise<string> {
 export async function matchTagsToCommits(
   sha: string,
   tags: IGitTag[],
-  matcher: (msg: string, sha: string) => SemVer | null
+  matcher: (msg: string, hash: string) => SemVer | null
 ): Promise<[SemVer | null, ICommit[]]> {
   const octo = getOctokit();
   const commitList: ICommit[] = [];


### PR DESCRIPTION
To avoid getting an ever-growing list of draft-releases, instead of
checking only the next minor and next major versions for draft release
updates, check every draft release matching our version prefix.

In other words, we just re-use the one draft release every time, until
it turns into an RC or release.