### PR TITLE
fix(sdkver): don't re-use draft releases on release branches

### DIFF
--- a/dist/bump/index.js
+++ b/dist/bump/index.js
@@ -12175,7 +12175,10 @@ function bumpSdkVer(config, bumpInfo, releaseMode, sdkVerBumpType, headSha, bran
             return false; // should never happen
         let bumped = false;
         const changelog = yield (0, changelog_1.generateChangelog)(bumpInfo);
-        bumped = yield publishBump(nextVersion, releaseMode, headSha, changelog, isBranchAllowedToPublish, latestDraft === null || latestDraft === void 0 ? void 0 : latestDraft.id);
+        bumped = yield publishBump(nextVersion, releaseMode, headSha, changelog, isBranchAllowedToPublish, 
+        // Re-use the latest draft release only when not running on a release branch,
+        // otherwise we might randomly reset a `dev-N` number chain.
+        !isReleaseBranch ? latestDraft === null || latestDraft === void 0 ? void 0 : latestDraft.id : undefined);
         if (!bumped && !isReleaseBranch) {
             core.info("ℹ️ No bump was performed");
         }

--- a/dist/validate/index.js
+++ b/dist/validate/index.js
@@ -12135,7 +12135,10 @@ function bumpSdkVer(config, bumpInfo, releaseMode, sdkVerBumpType, headSha, bran
             return false; // should never happen
         let bumped = false;
         const changelog = yield (0, changelog_1.generateChangelog)(bumpInfo);
-        bumped = yield publishBump(nextVersion, releaseMode, headSha, changelog, isBranchAllowedToPublish, latestDraft === null || latestDraft === void 0 ? void 0 : latestDraft.id);
+        bumped = yield publishBump(nextVersion, releaseMode, headSha, changelog, isBranchAllowedToPublish, 
+        // Re-use the latest draft release only when not running on a release branch,
+        // otherwise we might randomly reset a `dev-N` number chain.
+        !isReleaseBranch ? latestDraft === null || latestDraft === void 0 ? void 0 : latestDraft.id : undefined);
         if (!bumped && !isReleaseBranch) {
             core.info("ℹ️ No bump was performed");
         }

--- a/src/bump.ts
+++ b/src/bump.ts
@@ -752,7 +752,9 @@ export async function bumpSdkVer(
     headSha,
     changelog,
     isBranchAllowedToPublish,
-    latestDraft?.id
+    // Re-use the latest draft release only when not running on a release branch,
+    // otherwise we might randomly reset a `dev-N` number chain.
+    !isReleaseBranch ? latestDraft?.id : undefined
   );
 
   if (!bumped && !isReleaseBranch) {


### PR DESCRIPTION
Re-using a draft release from a release branch will reset the `dev-N` numbering, so let's only re-use draft releases from non-release branches.