### PR TITLE
fix(sdkver): avoid double bump on release branches

### DIFF
--- a/dist/bump/index.js
+++ b/dist/bump/index.js
@@ -14700,7 +14700,7 @@ class SemVer {
             if (lhs.prerelease && rhs.prerelease) {
                 const l = +((_c = (_b = (_a = firstNum.exec(lhs.prerelease)) === null || _a === void 0 ? void 0 : _a.groups) === null || _b === void 0 ? void 0 : _b.preversion) !== null && _c !== void 0 ? _c : 0);
                 const r = +((_f = (_e = (_d = firstNum.exec(rhs.prerelease)) === null || _d === void 0 ? void 0 : _d.groups) === null || _e === void 0 ? void 0 : _e.preversion) !== null && _f !== void 0 ? _f : 0);
-                core.debug(`sort: ${rhs} is subver ${l}, ${lhs} is subver ${l}`);
+                core.debug(`sort: ${rhs} is subver ${r}, ${lhs} is subver ${l}`);
                 if (l === r) {
                     sortResult = lhs.prerelease.localeCompare(rhs.prerelease);
                 }

--- a/dist/bump/index.js
+++ b/dist/bump/index.js
@@ -12111,7 +12111,7 @@ function getNextSdkVer(currentVersion, sdkVerBumpType, isReleaseBranch, headMatc
                 // Current HEAD is a dev prerelease
                 nextVersion = semver_1.SemVer.copy(currentVersion);
             }
-            nextVersion.prerelease = "rc1";
+            nextVersion.prerelease = `${RC_PREFIX}1`;
         }
         else if (sdkVerBumpType === "dev") {
             // TODO: decide on how best to handle hasBreakingChange in this case
@@ -18181,12 +18181,12 @@ function findPair(items, key) {
     return undefined;
 }
 class YAMLMap extends Collection.Collection {
-    static get tagName() {
-        return 'tag:yaml.org,2002:map';
-    }
     constructor(schema) {
         super(Node.MAP, schema);
         this.items = [];
+    }
+    static get tagName() {
+        return 'tag:yaml.org,2002:map';
     }
     /**
      * Adds a value to the collection.
@@ -18295,12 +18295,12 @@ var Scalar = __nccwpck_require__(9338);
 var toJS = __nccwpck_require__(2463);
 
 class YAMLSeq extends Collection.Collection {
-    static get tagName() {
-        return 'tag:yaml.org,2002:seq';
-    }
     constructor(schema) {
         super(Node.SEQ, schema);
         this.items = [];
+    }
+    static get tagName() {
+        return 'tag:yaml.org,2002:seq';
     }
     add(value) {
         this.items.push(value);
@@ -22293,7 +22293,6 @@ function createStringifyContext(doc, options) {
         doubleQuotedAsJSON: false,
         doubleQuotedMinMultiLineLength: 40,
         falseStr: 'false',
-        flowCollectionPadding: true,
         indentSeq: true,
         lineWidth: 80,
         minContentWidth: 20,
@@ -22317,7 +22316,6 @@ function createStringifyContext(doc, options) {
     return {
         anchors: new Set(),
         doc,
-        flowCollectionPadding: opt.flowCollectionPadding ? ' ' : '',
         indent: '',
         indentStep: typeof opt.indent === 'number' ? ' '.repeat(opt.indent) : '  ',
         inFlow,
@@ -22475,7 +22473,7 @@ function stringifyBlockCollection({ comment, items }, ctx, { blockItemPrefix, fl
     return str;
 }
 function stringifyFlowCollection({ comment, items }, ctx, { flowChars, itemIndent, onComment }) {
-    const { indent, indentStep, flowCollectionPadding: fcPadding, options: { commentString } } = ctx;
+    const { indent, indentStep, options: { commentString } } = ctx;
     itemIndent += indentStep;
     const itemCtx = Object.assign({}, ctx, {
         indent: itemIndent,
@@ -22544,7 +22542,7 @@ function stringifyFlowCollection({ comment, items }, ctx, { flowChars, itemInden
             str += `\n${indent}${end}`;
         }
         else {
-            str = `${start}${fcPadding}${lines.join(' ')}${fcPadding}${end}`;
+            str = `${start} ${lines.join(' ')} ${end}`;
         }
     }
     if (comment) {
@@ -22800,18 +22798,19 @@ function stringifyPair({ key, value }, ctx, onComment, onChompKeep) {
         if (keyComment)
             str += stringifyComment.lineComment(str, ctx.indent, commentString(keyComment));
     }
-    let vsb, vcb, valueComment;
+    let vcb = '';
+    let valueComment = null;
     if (Node.isNode(value)) {
-        vsb = !!value.spaceBefore;
-        vcb = value.commentBefore;
+        if (value.spaceBefore)
+            vcb = '\n';
+        if (value.commentBefore) {
+            const cs = commentString(value.commentBefore);
+            vcb += `\n${stringifyComment.indentComment(cs, ctx.indent)}`;
+        }
         valueComment = value.comment;
     }
-    else {
-        vsb = false;
-        vcb = null;
-        valueComment = null;
-        if (value && typeof value === 'object')
-            value = doc.createNode(value);
+    else if (value && typeof value === 'object') {
+        value = doc.createNode(value);
     }
     ctx.implicitKey = false;
     if (!explicitKey && !keyComment && Node.isScalar(value))
@@ -22826,50 +22825,24 @@ function stringifyPair({ key, value }, ctx, onComment, onChompKeep) {
         !value.tag &&
         !value.anchor) {
         // If indentSeq === false, consider '- ' as part of indentation where possible
-        ctx.indent = ctx.indent.substring(2);
+        ctx.indent = ctx.indent.substr(2);
     }
     let valueCommentDone = false;
     const valueStr = stringify.stringify(value, ctx, () => (valueCommentDone = true), () => (chompKeep = true));
     let ws = ' ';
-    if (keyComment || vsb || vcb) {
-        ws = vsb ? '\n' : '';
-        if (vcb) {
-            const cs = commentString(vcb);
-            ws += `\n${stringifyComment.indentComment(cs, ctx.indent)}`;
-        }
-        if (valueStr === '' && !ctx.inFlow) {
-            if (ws === '\n')
-                ws = '\n\n';
-        }
-        else {
-            ws += `\n${ctx.indent}`;
-        }
+    if (vcb || keyComment) {
+        if (valueStr === '' && !ctx.inFlow)
+            ws = vcb === '\n' ? '\n\n' : vcb;
+        else
+            ws = `${vcb}\n${ctx.indent}`;
     }
     else if (!explicitKey && Node.isCollection(value)) {
-        const vs0 = valueStr[0];
-        const nl0 = valueStr.indexOf('\n');
-        const hasNewline = nl0 !== -1;
-        const flow = ctx.inFlow ?? value.flow ?? value.items.length === 0;
-        if (hasNewline || !flow) {
-            let hasPropsLine = false;
-            if (hasNewline && (vs0 === '&' || vs0 === '!')) {
-                let sp0 = valueStr.indexOf(' ');
-                if (vs0 === '&' &&
-                    sp0 !== -1 &&
-                    sp0 < nl0 &&
-                    valueStr[sp0 + 1] === '!') {
-                    sp0 = valueStr.indexOf(' ', sp0 + 1);
-                }
-                if (sp0 === -1 || nl0 < sp0)
-                    hasPropsLine = true;
-            }
-            if (!hasPropsLine)
-                ws = `\n${ctx.indent}`;
-        }
+        const flow = valueStr[0] === '[' || valueStr[0] === '{';
+        if (!flow || valueStr.includes('\n'))
+            ws = `\n${ctx.indent}`;
     }
-    else if (valueStr === '' || valueStr[0] === '\n') {
+    else if (valueStr === '' || valueStr[0] === '\n')
         ws = '';
-    }
     str += ws + valueStr;
     if (ctx.inFlow) {
         if (valueCommentDone && onComment)
@@ -23127,7 +23100,7 @@ function blockString({ comment, type, value }, ctx, onComment, onChompKeep) {
 }
 function plainString(item, ctx, onComment, onChompKeep) {
     const { type, value } = item;
-    const { actualString, implicitKey, indent, indentStep, inFlow } = ctx;
+    const { actualString, implicitKey, indent, inFlow } = ctx;
     if ((implicitKey && /[\n[\]{},]/.test(value)) ||
         (inFlow && /[[\]{},]/.test(value))) {
         return quotedString(value, ctx);
@@ -23151,14 +23124,9 @@ function plainString(item, ctx, onComment, onChompKeep) {
         // Where allowed & type not set explicitly, prefer block style for multiline strings
         return blockString(item, ctx, onComment, onChompKeep);
     }
-    if (containsDocumentMarker(value)) {
-        if (indent === '') {
-            ctx.forceBlockIndent = true;
-            return blockString(item, ctx, onComment, onChompKeep);
-        }
-        else if (implicitKey && indent === indentStep) {
-            return quotedString(value, ctx);
-        }
+    if (indent === '' && containsDocumentMarker(value)) {
+        ctx.forceBlockIndent = true;
+        return blockString(item, ctx, onComment, onChompKeep);
     }
     const str = value.replace(/\n+/g, `$&\n${indent}`);
     // Verify that output will be parsed as a string, as e.g. plain numbers and

--- a/dist/cli/index.js
+++ b/dist/cli/index.js
@@ -12091,7 +12091,7 @@ class SemVer {
             if (lhs.prerelease && rhs.prerelease) {
                 const l = +((_c = (_b = (_a = firstNum.exec(lhs.prerelease)) === null || _a === void 0 ? void 0 : _a.groups) === null || _b === void 0 ? void 0 : _b.preversion) !== null && _c !== void 0 ? _c : 0);
                 const r = +((_f = (_e = (_d = firstNum.exec(rhs.prerelease)) === null || _d === void 0 ? void 0 : _d.groups) === null || _e === void 0 ? void 0 : _e.preversion) !== null && _f !== void 0 ? _f : 0);
-                core.debug(`sort: ${rhs} is subver ${l}, ${lhs} is subver ${l}`);
+                core.debug(`sort: ${rhs} is subver ${r}, ${lhs} is subver ${l}`);
                 if (l === r) {
                     sortResult = lhs.prerelease.localeCompare(rhs.prerelease);
                 }

--- a/dist/cli/index.js
+++ b/dist/cli/index.js
@@ -18616,12 +18616,12 @@ function findPair(items, key) {
     return undefined;
 }
 class YAMLMap extends Collection.Collection {
-    static get tagName() {
-        return 'tag:yaml.org,2002:map';
-    }
     constructor(schema) {
         super(Node.MAP, schema);
         this.items = [];
+    }
+    static get tagName() {
+        return 'tag:yaml.org,2002:map';
     }
     /**
      * Adds a value to the collection.
@@ -18730,12 +18730,12 @@ var Scalar = __nccwpck_require__(9338);
 var toJS = __nccwpck_require__(2463);
 
 class YAMLSeq extends Collection.Collection {
-    static get tagName() {
-        return 'tag:yaml.org,2002:seq';
-    }
     constructor(schema) {
         super(Node.SEQ, schema);
         this.items = [];
+    }
+    static get tagName() {
+        return 'tag:yaml.org,2002:seq';
     }
     add(value) {
         this.items.push(value);
@@ -22728,7 +22728,6 @@ function createStringifyContext(doc, options) {
         doubleQuotedAsJSON: false,
         doubleQuotedMinMultiLineLength: 40,
         falseStr: 'false',
-        flowCollectionPadding: true,
         indentSeq: true,
         lineWidth: 80,
         minContentWidth: 20,
@@ -22752,7 +22751,6 @@ function createStringifyContext(doc, options) {
     return {
         anchors: new Set(),
         doc,
-        flowCollectionPadding: opt.flowCollectionPadding ? ' ' : '',
         indent: '',
         indentStep: typeof opt.indent === 'number' ? ' '.repeat(opt.indent) : '  ',
         inFlow,
@@ -22910,7 +22908,7 @@ function stringifyBlockCollection({ comment, items }, ctx, { blockItemPrefix, fl
     return str;
 }
 function stringifyFlowCollection({ comment, items }, ctx, { flowChars, itemIndent, onComment }) {
-    const { indent, indentStep, flowCollectionPadding: fcPadding, options: { commentString } } = ctx;
+    const { indent, indentStep, options: { commentString } } = ctx;
     itemIndent += indentStep;
     const itemCtx = Object.assign({}, ctx, {
         indent: itemIndent,
@@ -22979,7 +22977,7 @@ function stringifyFlowCollection({ comment, items }, ctx, { flowChars, itemInden
             str += `\n${indent}${end}`;
         }
         else {
-            str = `${start}${fcPadding}${lines.join(' ')}${fcPadding}${end}`;
+            str = `${start} ${lines.join(' ')} ${end}`;
         }
     }
     if (comment) {
@@ -23235,18 +23233,19 @@ function stringifyPair({ key, value }, ctx, onComment, onChompKeep) {
         if (keyComment)
             str += stringifyComment.lineComment(str, ctx.indent, commentString(keyComment));
     }
-    let vsb, vcb, valueComment;
+    let vcb = '';
+    let valueComment = null;
     if (Node.isNode(value)) {
-        vsb = !!value.spaceBefore;
-        vcb = value.commentBefore;
+        if (value.spaceBefore)
+            vcb = '\n';
+        if (value.commentBefore) {
+            const cs = commentString(value.commentBefore);
+            vcb += `\n${stringifyComment.indentComment(cs, ctx.indent)}`;
+        }
         valueComment = value.comment;
     }
-    else {
-        vsb = false;
-        vcb = null;
-        valueComment = null;
-        if (value && typeof value === 'object')
-            value = doc.createNode(value);
+    else if (value && typeof value === 'object') {
+        value = doc.createNode(value);
     }
     ctx.implicitKey = false;
     if (!explicitKey && !keyComment && Node.isScalar(value))
@@ -23261,50 +23260,24 @@ function stringifyPair({ key, value }, ctx, onComment, onChompKeep) {
         !value.tag &&
         !value.anchor) {
         // If indentSeq === false, consider '- ' as part of indentation where possible
-        ctx.indent = ctx.indent.substring(2);
+        ctx.indent = ctx.indent.substr(2);
     }
     let valueCommentDone = false;
     const valueStr = stringify.stringify(value, ctx, () => (valueCommentDone = true), () => (chompKeep = true));
     let ws = ' ';
-    if (keyComment || vsb || vcb) {
-        ws = vsb ? '\n' : '';
-        if (vcb) {
-            const cs = commentString(vcb);
-            ws += `\n${stringifyComment.indentComment(cs, ctx.indent)}`;
-        }
-        if (valueStr === '' && !ctx.inFlow) {
-            if (ws === '\n')
-                ws = '\n\n';
-        }
-        else {
-            ws += `\n${ctx.indent}`;
-        }
+    if (vcb || keyComment) {
+        if (valueStr === '' && !ctx.inFlow)
+            ws = vcb === '\n' ? '\n\n' : vcb;
+        else
+            ws = `${vcb}\n${ctx.indent}`;
     }
     else if (!explicitKey && Node.isCollection(value)) {
-        const vs0 = valueStr[0];
-        const nl0 = valueStr.indexOf('\n');
-        const hasNewline = nl0 !== -1;
-        const flow = ctx.inFlow ?? value.flow ?? value.items.length === 0;
-        if (hasNewline || !flow) {
-            let hasPropsLine = false;
-            if (hasNewline && (vs0 === '&' || vs0 === '!')) {
-                let sp0 = valueStr.indexOf(' ');
-                if (vs0 === '&' &&
-                    sp0 !== -1 &&
-                    sp0 < nl0 &&
-                    valueStr[sp0 + 1] === '!') {
-                    sp0 = valueStr.indexOf(' ', sp0 + 1);
-                }
-                if (sp0 === -1 || nl0 < sp0)
-                    hasPropsLine = true;
-            }
-            if (!hasPropsLine)
-                ws = `\n${ctx.indent}`;
-        }
+        const flow = valueStr[0] === '[' || valueStr[0] === '{';
+        if (!flow || valueStr.includes('\n'))
+            ws = `\n${ctx.indent}`;
     }
-    else if (valueStr === '' || valueStr[0] === '\n') {
+    else if (valueStr === '' || valueStr[0] === '\n')
         ws = '';
-    }
     str += ws + valueStr;
     if (ctx.inFlow) {
         if (valueCommentDone && onComment)
@@ -23562,7 +23535,7 @@ function blockString({ comment, type, value }, ctx, onComment, onChompKeep) {
 }
 function plainString(item, ctx, onComment, onChompKeep) {
     const { type, value } = item;
-    const { actualString, implicitKey, indent, indentStep, inFlow } = ctx;
+    const { actualString, implicitKey, indent, inFlow } = ctx;
     if ((implicitKey && /[\n[\]{},]/.test(value)) ||
         (inFlow && /[[\]{},]/.test(value))) {
         return quotedString(value, ctx);
@@ -23586,14 +23559,9 @@ function plainString(item, ctx, onComment, onChompKeep) {
         // Where allowed & type not set explicitly, prefer block style for multiline strings
         return blockString(item, ctx, onComment, onChompKeep);
     }
-    if (containsDocumentMarker(value)) {
-        if (indent === '') {
-            ctx.forceBlockIndent = true;
-            return blockString(item, ctx, onComment, onChompKeep);
-        }
-        else if (implicitKey && indent === indentStep) {
-            return quotedString(value, ctx);
-        }
+    if (indent === '' && containsDocumentMarker(value)) {
+        ctx.forceBlockIndent = true;
+        return blockString(item, ctx, onComment, onChompKeep);
     }
     const str = value.replace(/\n+/g, `$&\n${indent}`);
     // Verify that output will be parsed as a string, as e.g. plain numbers and

--- a/dist/cli/index.js
+++ b/dist/cli/index.js
@@ -18616,12 +18616,12 @@ function findPair(items, key) {
     return undefined;
 }
 class YAMLMap extends Collection.Collection {
+    static get tagName() {
+        return 'tag:yaml.org,2002:map';
+    }
     constructor(schema) {
         super(Node.MAP, schema);
         this.items = [];
-    }
-    static get tagName() {
-        return 'tag:yaml.org,2002:map';
     }
     /**
      * Adds a value to the collection.
@@ -18730,12 +18730,12 @@ var Scalar = __nccwpck_require__(9338);
 var toJS = __nccwpck_require__(2463);
 
 class YAMLSeq extends Collection.Collection {
+    static get tagName() {
+        return 'tag:yaml.org,2002:seq';
+    }
     constructor(schema) {
         super(Node.SEQ, schema);
         this.items = [];
-    }
-    static get tagName() {
-        return 'tag:yaml.org,2002:seq';
     }
     add(value) {
         this.items.push(value);
@@ -22728,6 +22728,7 @@ function createStringifyContext(doc, options) {
         doubleQuotedAsJSON: false,
         doubleQuotedMinMultiLineLength: 40,
         falseStr: 'false',
+        flowCollectionPadding: true,
         indentSeq: true,
         lineWidth: 80,
         minContentWidth: 20,
@@ -22751,6 +22752,7 @@ function createStringifyContext(doc, options) {
     return {
         anchors: new Set(),
         doc,
+        flowCollectionPadding: opt.flowCollectionPadding ? ' ' : '',
         indent: '',
         indentStep: typeof opt.indent === 'number' ? ' '.repeat(opt.indent) : '  ',
         inFlow,
@@ -22908,7 +22910,7 @@ function stringifyBlockCollection({ comment, items }, ctx, { blockItemPrefix, fl
     return str;
 }
 function stringifyFlowCollection({ comment, items }, ctx, { flowChars, itemIndent, onComment }) {
-    const { indent, indentStep, options: { commentString } } = ctx;
+    const { indent, indentStep, flowCollectionPadding: fcPadding, options: { commentString } } = ctx;
     itemIndent += indentStep;
     const itemCtx = Object.assign({}, ctx, {
         indent: itemIndent,
@@ -22977,7 +22979,7 @@ function stringifyFlowCollection({ comment, items }, ctx, { flowChars, itemInden
             str += `\n${indent}${end}`;
         }
         else {
-            str = `${start} ${lines.join(' ')} ${end}`;
+            str = `${start}${fcPadding}${lines.join(' ')}${fcPadding}${end}`;
         }
     }
     if (comment) {
@@ -23233,19 +23235,18 @@ function stringifyPair({ key, value }, ctx, onComment, onChompKeep) {
         if (keyComment)
             str += stringifyComment.lineComment(str, ctx.indent, commentString(keyComment));
     }
-    let vcb = '';
-    let valueComment = null;
+    let vsb, vcb, valueComment;
     if (Node.isNode(value)) {
-        if (value.spaceBefore)
-            vcb = '\n';
-        if (value.commentBefore) {
-            const cs = commentString(value.commentBefore);
-            vcb += `\n${stringifyComment.indentComment(cs, ctx.indent)}`;
-        }
+        vsb = !!value.spaceBefore;
+        vcb = value.commentBefore;
         valueComment = value.comment;
     }
-    else if (value && typeof value === 'object') {
-        value = doc.createNode(value);
+    else {
+        vsb = false;
+        vcb = null;
+        valueComment = null;
+        if (value && typeof value === 'object')
+            value = doc.createNode(value);
     }
     ctx.implicitKey = false;
     if (!explicitKey && !keyComment && Node.isScalar(value))
@@ -23260,24 +23261,50 @@ function stringifyPair({ key, value }, ctx, onComment, onChompKeep) {
         !value.tag &&
         !value.anchor) {
         // If indentSeq === false, consider '- ' as part of indentation where possible
-        ctx.indent = ctx.indent.substr(2);
+        ctx.indent = ctx.indent.substring(2);
     }
     let valueCommentDone = false;
     const valueStr = stringify.stringify(value, ctx, () => (valueCommentDone = true), () => (chompKeep = true));
     let ws = ' ';
-    if (vcb || keyComment) {
-        if (valueStr === '' && !ctx.inFlow)
-            ws = vcb === '\n' ? '\n\n' : vcb;
-        else
-            ws = `${vcb}\n${ctx.indent}`;
+    if (keyComment || vsb || vcb) {
+        ws = vsb ? '\n' : '';
+        if (vcb) {
+            const cs = commentString(vcb);
+            ws += `\n${stringifyComment.indentComment(cs, ctx.indent)}`;
+        }
+        if (valueStr === '' && !ctx.inFlow) {
+            if (ws === '\n')
+                ws = '\n\n';
+        }
+        else {
+            ws += `\n${ctx.indent}`;
+        }
     }
     else if (!explicitKey && Node.isCollection(value)) {
-        const flow = valueStr[0] === '[' || valueStr[0] === '{';
-        if (!flow || valueStr.includes('\n'))
-            ws = `\n${ctx.indent}`;
+        const vs0 = valueStr[0];
+        const nl0 = valueStr.indexOf('\n');
+        const hasNewline = nl0 !== -1;
+        const flow = ctx.inFlow ?? value.flow ?? value.items.length === 0;
+        if (hasNewline || !flow) {
+            let hasPropsLine = false;
+            if (hasNewline && (vs0 === '&' || vs0 === '!')) {
+                let sp0 = valueStr.indexOf(' ');
+                if (vs0 === '&' &&
+                    sp0 !== -1 &&
+                    sp0 < nl0 &&
+                    valueStr[sp0 + 1] === '!') {
+                    sp0 = valueStr.indexOf(' ', sp0 + 1);
+                }
+                if (sp0 === -1 || nl0 < sp0)
+                    hasPropsLine = true;
+            }
+            if (!hasPropsLine)
+                ws = `\n${ctx.indent}`;
+        }
     }
-    else if (valueStr === '' || valueStr[0] === '\n')
+    else if (valueStr === '' || valueStr[0] === '\n') {
         ws = '';
+    }
     str += ws + valueStr;
     if (ctx.inFlow) {
         if (valueCommentDone && onComment)
@@ -23535,7 +23562,7 @@ function blockString({ comment, type, value }, ctx, onComment, onChompKeep) {
 }
 function plainString(item, ctx, onComment, onChompKeep) {
     const { type, value } = item;
-    const { actualString, implicitKey, indent, inFlow } = ctx;
+    const { actualString, implicitKey, indent, indentStep, inFlow } = ctx;
     if ((implicitKey && /[\n[\]{},]/.test(value)) ||
         (inFlow && /[[\]{},]/.test(value))) {
         return quotedString(value, ctx);
@@ -23559,9 +23586,14 @@ function plainString(item, ctx, onComment, onChompKeep) {
         // Where allowed & type not set explicitly, prefer block style for multiline strings
         return blockString(item, ctx, onComment, onChompKeep);
     }
-    if (indent === '' && containsDocumentMarker(value)) {
-        ctx.forceBlockIndent = true;
-        return blockString(item, ctx, onComment, onChompKeep);
+    if (containsDocumentMarker(value)) {
+        if (indent === '') {
+            ctx.forceBlockIndent = true;
+            return blockString(item, ctx, onComment, onChompKeep);
+        }
+        else if (implicitKey && indent === indentStep) {
+            return quotedString(value, ctx);
+        }
     }
     const str = value.replace(/\n+/g, `$&\n${indent}`);
     // Verify that output will be parsed as a string, as e.g. plain numbers and

--- a/dist/validate/index.js
+++ b/dist/validate/index.js
@@ -11953,6 +11953,7 @@ function bumpSemVer(config, bumpInfo, releaseMode, branchName, headSha, isBranch
 }
 exports.bumpSemVer = bumpSemVer;
 function getNextSdkVer(currentVersion, sdkVerBumpType, isReleaseBranch, headMatchesTag, hasBreakingChange, devPrereleaseText, isInitialDevelopment) {
+    var _a;
     const currentIsRc = currentVersion.prerelease.startsWith(RC_PREFIX);
     const currentIsRel = currentVersion.prerelease === "";
     const currentBuildInfo = currentVersion.build;
@@ -11967,8 +11968,13 @@ function getNextSdkVer(currentVersion, sdkVerBumpType, isReleaseBranch, headMatc
             v.build = currentBuildInfo;
         return v;
     };
-    core.info(`Determining SDK bump for version ${currentVersion.toString()}:`);
-    core.info(` - current version type: ${currentIsRel ? "release" : currentIsRc ? "release candidate" : "dev"}`);
+    const currentVersionType = currentIsRel
+        ? "release"
+        : currentIsRc
+            ? "release candidate"
+            : "dev";
+    core.info(`Determining SDK bump for version ${currentVersion.toString()}${headMatchesTag ? " (HEAD)" : ""}:`);
+    core.info(` - current version type: ${currentVersionType}`);
     core.info(` - bump type: ${sdkVerBumpType}`);
     core.info(` - branch type: ${isReleaseBranch ? "" : "not "}release`);
     core.info(` - breaking changes: ${hasBreakingChange ? "yes" : "no"}`);
@@ -11995,7 +12001,13 @@ function getNextSdkVer(currentVersion, sdkVerBumpType, isReleaseBranch, headMatc
             !(currentIsRc && currentVersion.minor === 0 && currentVersion.patch === 0)) {
             die("Breaking changes are not allowed on release branches.");
         }
-        if (sdkVerBumpType === "rel") {
+        // Only bump if we need to; we don't want to generate a new RC or release
+        // when nothing has changed since the last RC or release, unless it is a
+        // promotion from RC to full release.
+        if (headMatchesTag && !(sdkVerBumpType === "rel" && currentIsRc)) {
+            core.info(` - head matches latest tag on release branch`);
+        }
+        else if (sdkVerBumpType === "rel") {
             if (currentIsRel) {
                 // Pushes on release branches with a finalized release always
                 // bump PATCH, no exception.
@@ -12011,7 +12023,6 @@ function getNextSdkVer(currentVersion, sdkVerBumpType, isReleaseBranch, headMatc
         else {
             // Bumps for "rc" and "dev" are identical on a release branch
             if (currentIsRc) {
-                // Current version is an rc, so bump that
                 nextVersion = currentVersion.nextPrerelease();
                 if (!nextVersion) {
                     die(`Unable to bump RC version for: ${currentVersion.toString()}; ` +
@@ -12093,8 +12104,8 @@ function getNextSdkVer(currentVersion, sdkVerBumpType, isReleaseBranch, headMatc
             }
         }
     }
-    core.info(` - next version: ${nextVersion === null || nextVersion === void 0 ? void 0 : nextVersion.toString()}`);
-    if (!nextVersion) {
+    core.info(` - next version: ${(_a = nextVersion === null || nextVersion === void 0 ? void 0 : nextVersion.toString()) !== null && _a !== void 0 ? _a : "none"}`);
+    if (!nextVersion && !headMatchesTag) {
         die(`Unable to bump version for: ${currentVersion.toString()}`);
     }
     return nextVersion;
@@ -12103,7 +12114,7 @@ function getNextSdkVer(currentVersion, sdkVerBumpType, isReleaseBranch, headMatc
  * Bump and release/tag SDK versions
  */
 function bumpSdkVer(config, bumpInfo, releaseMode, sdkVerBumpType, headSha, branchName, isBranchAllowedToPublish) {
-    var _a, _b, _c;
+    var _a, _b, _c, _d;
     return __awaiter(this, void 0, void 0, function* () {
         const isReleaseBranch = branchName.match(config.releaseBranches);
         const hasBreakingChange = bumpInfo.processedCommits.some(c => { var _a; return (_a = c.message) === null || _a === void 0 ? void 0 : _a.breakingChange; });
@@ -12132,18 +12143,18 @@ function bumpSdkVer(config, bumpInfo, releaseMode, sdkVerBumpType, headSha, bran
         const headMatchesTag = yield (0, github_1.currentHeadMatchesTag)(cv.toString());
         const nextVersion = getNextSdkVer(cv, sdkVerBumpType, isReleaseBranch, headMatchesTag, hasBreakingChange, (_c = config.prereleasePrefix) !== null && _c !== void 0 ? _c : "dev", // SdkVer dictates dev versions
         config.initialDevelopment);
-        if (!nextVersion)
-            return false; // should never happen
         let bumped = false;
-        const changelog = yield (0, changelog_1.generateChangelog)(bumpInfo);
-        bumped = yield publishBump(nextVersion, releaseMode, headSha, changelog, isBranchAllowedToPublish, 
-        // Re-use the latest draft release only when not running on a release branch,
-        // otherwise we might randomly reset a `dev-N` number chain.
-        !isReleaseBranch ? latestDraft === null || latestDraft === void 0 ? void 0 : latestDraft.id : undefined);
-        if (!bumped && !isReleaseBranch) {
+        if (nextVersion) {
+            const changelog = yield (0, changelog_1.generateChangelog)(bumpInfo);
+            bumped = yield publishBump(nextVersion, releaseMode, headSha, changelog, isBranchAllowedToPublish, 
+            // Re-use the latest draft release only when not running on a release branch,
+            // otherwise we might randomly reset a `dev-N` number chain.
+            !isReleaseBranch ? latestDraft === null || latestDraft === void 0 ? void 0 : latestDraft.id : undefined);
+        }
+        if (!bumped) {
             core.info("ℹ️ No bump was performed");
         }
-        core.setOutput("next-version", nextVersion.toString());
+        core.setOutput("next-version", (_d = nextVersion === null || nextVersion === void 0 ? void 0 : nextVersion.toString()) !== null && _d !== void 0 ? _d : "");
         core.endGroup();
         return bumped;
     });
@@ -18141,12 +18152,12 @@ function findPair(items, key) {
     return undefined;
 }
 class YAMLMap extends Collection.Collection {
+    static get tagName() {
+        return 'tag:yaml.org,2002:map';
+    }
     constructor(schema) {
         super(Node.MAP, schema);
         this.items = [];
-    }
-    static get tagName() {
-        return 'tag:yaml.org,2002:map';
     }
     /**
      * Adds a value to the collection.
@@ -18255,12 +18266,12 @@ var Scalar = __nccwpck_require__(9338);
 var toJS = __nccwpck_require__(2463);
 
 class YAMLSeq extends Collection.Collection {
+    static get tagName() {
+        return 'tag:yaml.org,2002:seq';
+    }
     constructor(schema) {
         super(Node.SEQ, schema);
         this.items = [];
-    }
-    static get tagName() {
-        return 'tag:yaml.org,2002:seq';
     }
     add(value) {
         this.items.push(value);
@@ -22253,6 +22264,7 @@ function createStringifyContext(doc, options) {
         doubleQuotedAsJSON: false,
         doubleQuotedMinMultiLineLength: 40,
         falseStr: 'false',
+        flowCollectionPadding: true,
         indentSeq: true,
         lineWidth: 80,
         minContentWidth: 20,
@@ -22276,6 +22288,7 @@ function createStringifyContext(doc, options) {
     return {
         anchors: new Set(),
         doc,
+        flowCollectionPadding: opt.flowCollectionPadding ? ' ' : '',
         indent: '',
         indentStep: typeof opt.indent === 'number' ? ' '.repeat(opt.indent) : '  ',
         inFlow,
@@ -22433,7 +22446,7 @@ function stringifyBlockCollection({ comment, items }, ctx, { blockItemPrefix, fl
     return str;
 }
 function stringifyFlowCollection({ comment, items }, ctx, { flowChars, itemIndent, onComment }) {
-    const { indent, indentStep, options: { commentString } } = ctx;
+    const { indent, indentStep, flowCollectionPadding: fcPadding, options: { commentString } } = ctx;
     itemIndent += indentStep;
     const itemCtx = Object.assign({}, ctx, {
         indent: itemIndent,
@@ -22502,7 +22515,7 @@ function stringifyFlowCollection({ comment, items }, ctx, { flowChars, itemInden
             str += `\n${indent}${end}`;
         }
         else {
-            str = `${start} ${lines.join(' ')} ${end}`;
+            str = `${start}${fcPadding}${lines.join(' ')}${fcPadding}${end}`;
         }
     }
     if (comment) {
@@ -22758,19 +22771,18 @@ function stringifyPair({ key, value }, ctx, onComment, onChompKeep) {
         if (keyComment)
             str += stringifyComment.lineComment(str, ctx.indent, commentString(keyComment));
     }
-    let vcb = '';
-    let valueComment = null;
+    let vsb, vcb, valueComment;
     if (Node.isNode(value)) {
-        if (value.spaceBefore)
-            vcb = '\n';
-        if (value.commentBefore) {
-            const cs = commentString(value.commentBefore);
-            vcb += `\n${stringifyComment.indentComment(cs, ctx.indent)}`;
-        }
+        vsb = !!value.spaceBefore;
+        vcb = value.commentBefore;
         valueComment = value.comment;
     }
-    else if (value && typeof value === 'object') {
-        value = doc.createNode(value);
+    else {
+        vsb = false;
+        vcb = null;
+        valueComment = null;
+        if (value && typeof value === 'object')
+            value = doc.createNode(value);
     }
     ctx.implicitKey = false;
     if (!explicitKey && !keyComment && Node.isScalar(value))
@@ -22785,24 +22797,50 @@ function stringifyPair({ key, value }, ctx, onComment, onChompKeep) {
         !value.tag &&
         !value.anchor) {
         // If indentSeq === false, consider '- ' as part of indentation where possible
-        ctx.indent = ctx.indent.substr(2);
+        ctx.indent = ctx.indent.substring(2);
     }
     let valueCommentDone = false;
     const valueStr = stringify.stringify(value, ctx, () => (valueCommentDone = true), () => (chompKeep = true));
     let ws = ' ';
-    if (vcb || keyComment) {
-        if (valueStr === '' && !ctx.inFlow)
-            ws = vcb === '\n' ? '\n\n' : vcb;
-        else
-            ws = `${vcb}\n${ctx.indent}`;
+    if (keyComment || vsb || vcb) {
+        ws = vsb ? '\n' : '';
+        if (vcb) {
+            const cs = commentString(vcb);
+            ws += `\n${stringifyComment.indentComment(cs, ctx.indent)}`;
+        }
+        if (valueStr === '' && !ctx.inFlow) {
+            if (ws === '\n')
+                ws = '\n\n';
+        }
+        else {
+            ws += `\n${ctx.indent}`;
+        }
     }
     else if (!explicitKey && Node.isCollection(value)) {
-        const flow = valueStr[0] === '[' || valueStr[0] === '{';
-        if (!flow || valueStr.includes('\n'))
-            ws = `\n${ctx.indent}`;
+        const vs0 = valueStr[0];
+        const nl0 = valueStr.indexOf('\n');
+        const hasNewline = nl0 !== -1;
+        const flow = ctx.inFlow ?? value.flow ?? value.items.length === 0;
+        if (hasNewline || !flow) {
+            let hasPropsLine = false;
+            if (hasNewline && (vs0 === '&' || vs0 === '!')) {
+                let sp0 = valueStr.indexOf(' ');
+                if (vs0 === '&' &&
+                    sp0 !== -1 &&
+                    sp0 < nl0 &&
+                    valueStr[sp0 + 1] === '!') {
+                    sp0 = valueStr.indexOf(' ', sp0 + 1);
+                }
+                if (sp0 === -1 || nl0 < sp0)
+                    hasPropsLine = true;
+            }
+            if (!hasPropsLine)
+                ws = `\n${ctx.indent}`;
+        }
     }
-    else if (valueStr === '' || valueStr[0] === '\n')
+    else if (valueStr === '' || valueStr[0] === '\n') {
         ws = '';
+    }
     str += ws + valueStr;
     if (ctx.inFlow) {
         if (valueCommentDone && onComment)
@@ -23060,7 +23098,7 @@ function blockString({ comment, type, value }, ctx, onComment, onChompKeep) {
 }
 function plainString(item, ctx, onComment, onChompKeep) {
     const { type, value } = item;
-    const { actualString, implicitKey, indent, inFlow } = ctx;
+    const { actualString, implicitKey, indent, indentStep, inFlow } = ctx;
     if ((implicitKey && /[\n[\]{},]/.test(value)) ||
         (inFlow && /[[\]{},]/.test(value))) {
         return quotedString(value, ctx);
@@ -23084,9 +23122,14 @@ function plainString(item, ctx, onComment, onChompKeep) {
         // Where allowed & type not set explicitly, prefer block style for multiline strings
         return blockString(item, ctx, onComment, onChompKeep);
     }
-    if (indent === '' && containsDocumentMarker(value)) {
-        ctx.forceBlockIndent = true;
-        return blockString(item, ctx, onComment, onChompKeep);
+    if (containsDocumentMarker(value)) {
+        if (indent === '') {
+            ctx.forceBlockIndent = true;
+            return blockString(item, ctx, onComment, onChompKeep);
+        }
+        else if (implicitKey && indent === indentStep) {
+            return quotedString(value, ctx);
+        }
     }
     const str = value.replace(/\n+/g, `$&\n${indent}`);
     // Verify that output will be parsed as a string, as e.g. plain numbers and

--- a/dist/validate/index.js
+++ b/dist/validate/index.js
@@ -12071,7 +12071,7 @@ function getNextSdkVer(currentVersion, sdkVerBumpType, isReleaseBranch, headMatc
                 // Current HEAD is a dev prerelease
                 nextVersion = semver_1.SemVer.copy(currentVersion);
             }
-            nextVersion.prerelease = "rc1";
+            nextVersion.prerelease = `${RC_PREFIX}1`;
         }
         else if (sdkVerBumpType === "dev") {
             // TODO: decide on how best to handle hasBreakingChange in this case
@@ -18141,12 +18141,12 @@ function findPair(items, key) {
     return undefined;
 }
 class YAMLMap extends Collection.Collection {
-    static get tagName() {
-        return 'tag:yaml.org,2002:map';
-    }
     constructor(schema) {
         super(Node.MAP, schema);
         this.items = [];
+    }
+    static get tagName() {
+        return 'tag:yaml.org,2002:map';
     }
     /**
      * Adds a value to the collection.
@@ -18255,12 +18255,12 @@ var Scalar = __nccwpck_require__(9338);
 var toJS = __nccwpck_require__(2463);
 
 class YAMLSeq extends Collection.Collection {
-    static get tagName() {
-        return 'tag:yaml.org,2002:seq';
-    }
     constructor(schema) {
         super(Node.SEQ, schema);
         this.items = [];
+    }
+    static get tagName() {
+        return 'tag:yaml.org,2002:seq';
     }
     add(value) {
         this.items.push(value);
@@ -22253,7 +22253,6 @@ function createStringifyContext(doc, options) {
         doubleQuotedAsJSON: false,
         doubleQuotedMinMultiLineLength: 40,
         falseStr: 'false',
-        flowCollectionPadding: true,
         indentSeq: true,
         lineWidth: 80,
         minContentWidth: 20,
@@ -22277,7 +22276,6 @@ function createStringifyContext(doc, options) {
     return {
         anchors: new Set(),
         doc,
-        flowCollectionPadding: opt.flowCollectionPadding ? ' ' : '',
         indent: '',
         indentStep: typeof opt.indent === 'number' ? ' '.repeat(opt.indent) : '  ',
         inFlow,
@@ -22435,7 +22433,7 @@ function stringifyBlockCollection({ comment, items }, ctx, { blockItemPrefix, fl
     return str;
 }
 function stringifyFlowCollection({ comment, items }, ctx, { flowChars, itemIndent, onComment }) {
-    const { indent, indentStep, flowCollectionPadding: fcPadding, options: { commentString } } = ctx;
+    const { indent, indentStep, options: { commentString } } = ctx;
     itemIndent += indentStep;
     const itemCtx = Object.assign({}, ctx, {
         indent: itemIndent,
@@ -22504,7 +22502,7 @@ function stringifyFlowCollection({ comment, items }, ctx, { flowChars, itemInden
             str += `\n${indent}${end}`;
         }
         else {
-            str = `${start}${fcPadding}${lines.join(' ')}${fcPadding}${end}`;
+            str = `${start} ${lines.join(' ')} ${end}`;
         }
     }
     if (comment) {
@@ -22760,18 +22758,19 @@ function stringifyPair({ key, value }, ctx, onComment, onChompKeep) {
         if (keyComment)
             str += stringifyComment.lineComment(str, ctx.indent, commentString(keyComment));
     }
-    let vsb, vcb, valueComment;
+    let vcb = '';
+    let valueComment = null;
     if (Node.isNode(value)) {
-        vsb = !!value.spaceBefore;
-        vcb = value.commentBefore;
+        if (value.spaceBefore)
+            vcb = '\n';
+        if (value.commentBefore) {
+            const cs = commentString(value.commentBefore);
+            vcb += `\n${stringifyComment.indentComment(cs, ctx.indent)}`;
+        }
         valueComment = value.comment;
     }
-    else {
-        vsb = false;
-        vcb = null;
-        valueComment = null;
-        if (value && typeof value === 'object')
-            value = doc.createNode(value);
+    else if (value && typeof value === 'object') {
+        value = doc.createNode(value);
     }
     ctx.implicitKey = false;
     if (!explicitKey && !keyComment && Node.isScalar(value))
@@ -22786,50 +22785,24 @@ function stringifyPair({ key, value }, ctx, onComment, onChompKeep) {
         !value.tag &&
         !value.anchor) {
         // If indentSeq === false, consider '- ' as part of indentation where possible
-        ctx.indent = ctx.indent.substring(2);
+        ctx.indent = ctx.indent.substr(2);
     }
     let valueCommentDone = false;
     const valueStr = stringify.stringify(value, ctx, () => (valueCommentDone = true), () => (chompKeep = true));
     let ws = ' ';
-    if (keyComment || vsb || vcb) {
-        ws = vsb ? '\n' : '';
-        if (vcb) {
-            const cs = commentString(vcb);
-            ws += `\n${stringifyComment.indentComment(cs, ctx.indent)}`;
-        }
-        if (valueStr === '' && !ctx.inFlow) {
-            if (ws === '\n')
-                ws = '\n\n';
-        }
-        else {
-            ws += `\n${ctx.indent}`;
-        }
+    if (vcb || keyComment) {
+        if (valueStr === '' && !ctx.inFlow)
+            ws = vcb === '\n' ? '\n\n' : vcb;
+        else
+            ws = `${vcb}\n${ctx.indent}`;
     }
     else if (!explicitKey && Node.isCollection(value)) {
-        const vs0 = valueStr[0];
-        const nl0 = valueStr.indexOf('\n');
-        const hasNewline = nl0 !== -1;
-        const flow = ctx.inFlow ?? value.flow ?? value.items.length === 0;
-        if (hasNewline || !flow) {
-            let hasPropsLine = false;
-            if (hasNewline && (vs0 === '&' || vs0 === '!')) {
-                let sp0 = valueStr.indexOf(' ');
-                if (vs0 === '&' &&
-                    sp0 !== -1 &&
-                    sp0 < nl0 &&
-                    valueStr[sp0 + 1] === '!') {
-                    sp0 = valueStr.indexOf(' ', sp0 + 1);
-                }
-                if (sp0 === -1 || nl0 < sp0)
-                    hasPropsLine = true;
-            }
-            if (!hasPropsLine)
-                ws = `\n${ctx.indent}`;
-        }
+        const flow = valueStr[0] === '[' || valueStr[0] === '{';
+        if (!flow || valueStr.includes('\n'))
+            ws = `\n${ctx.indent}`;
     }
-    else if (valueStr === '' || valueStr[0] === '\n') {
+    else if (valueStr === '' || valueStr[0] === '\n')
         ws = '';
-    }
     str += ws + valueStr;
     if (ctx.inFlow) {
         if (valueCommentDone && onComment)
@@ -23087,7 +23060,7 @@ function blockString({ comment, type, value }, ctx, onComment, onChompKeep) {
 }
 function plainString(item, ctx, onComment, onChompKeep) {
     const { type, value } = item;
-    const { actualString, implicitKey, indent, indentStep, inFlow } = ctx;
+    const { actualString, implicitKey, indent, inFlow } = ctx;
     if ((implicitKey && /[\n[\]{},]/.test(value)) ||
         (inFlow && /[[\]{},]/.test(value))) {
         return quotedString(value, ctx);
@@ -23111,14 +23084,9 @@ function plainString(item, ctx, onComment, onChompKeep) {
         // Where allowed & type not set explicitly, prefer block style for multiline strings
         return blockString(item, ctx, onComment, onChompKeep);
     }
-    if (containsDocumentMarker(value)) {
-        if (indent === '') {
-            ctx.forceBlockIndent = true;
-            return blockString(item, ctx, onComment, onChompKeep);
-        }
-        else if (implicitKey && indent === indentStep) {
-            return quotedString(value, ctx);
-        }
+    if (indent === '' && containsDocumentMarker(value)) {
+        ctx.forceBlockIndent = true;
+        return blockString(item, ctx, onComment, onChompKeep);
     }
     const str = value.replace(/\n+/g, `$&\n${indent}`);
     // Verify that output will be parsed as a string, as e.g. plain numbers and

--- a/dist/validate/index.js
+++ b/dist/validate/index.js
@@ -14660,7 +14660,7 @@ class SemVer {
             if (lhs.prerelease && rhs.prerelease) {
                 const l = +((_c = (_b = (_a = firstNum.exec(lhs.prerelease)) === null || _a === void 0 ? void 0 : _a.groups) === null || _b === void 0 ? void 0 : _b.preversion) !== null && _c !== void 0 ? _c : 0);
                 const r = +((_f = (_e = (_d = firstNum.exec(rhs.prerelease)) === null || _d === void 0 ? void 0 : _d.groups) === null || _e === void 0 ? void 0 : _e.preversion) !== null && _f !== void 0 ? _f : 0);
-                core.debug(`sort: ${rhs} is subver ${l}, ${lhs} is subver ${l}`);
+                core.debug(`sort: ${rhs} is subver ${r}, ${lhs} is subver ${l}`);
                 if (l === r) {
                     sortResult = lhs.prerelease.localeCompare(rhs.prerelease);
                 }

--- a/src/bump.ts
+++ b/src/bump.ts
@@ -657,7 +657,7 @@ function getNextSdkVer(
         // Current HEAD is a dev prerelease
         nextVersion = SemVer.copy(currentVersion);
       }
-      nextVersion.prerelease = "rc1";
+      nextVersion.prerelease = `${RC_PREFIX}1`;
     } else if (sdkVerBumpType === "dev") {
       // TODO: decide on how best to handle hasBreakingChange in this case
       if (currentIsRel || currentIsRc) {

--- a/src/semver.ts
+++ b/src/semver.ts
@@ -270,7 +270,7 @@ export class SemVer {
       if (lhs.prerelease && rhs.prerelease) {
         const l = +(firstNum.exec(lhs.prerelease)?.groups?.preversion ?? 0);
         const r = +(firstNum.exec(rhs.prerelease)?.groups?.preversion ?? 0);
-        core.debug(`sort: ${rhs} is subver ${l}, ${lhs} is subver ${l}`);
+        core.debug(`sort: ${rhs} is subver ${r}, ${lhs} is subver ${l}`);
         if (l === r) {
           sortResult = lhs.prerelease.localeCompare(rhs.prerelease);
         } else {

--- a/test/bump.sdkver.test.ts
+++ b/test/bump.sdkver.test.ts
@@ -170,8 +170,13 @@ const testFunction = async (p: SdkBumpTestParameters) => {
     expect(core.error).not.toHaveBeenCalled();
     expect(core.setFailed).not.toHaveBeenCalled();
   } else {
-    // Expect error
-    expect(core.setFailed).toHaveBeenCalledTimes(1);
+    if (!p.testDescription.includes("HEADisTag")) {
+      // Expect error
+      expect(core.setFailed).toHaveBeenCalledTimes(1);
+    } else {
+      expect(core.setFailed).not.toHaveBeenCalled();
+      expect(github.createRelease).not.toHaveBeenCalled();
+    }
   }
   expect(core.setOutput).toBeCalledWith("current-version", p.initialVersion);
 };
@@ -196,6 +201,7 @@ const testSuiteDefinitions = [
         ["from dev"             , "1.1.0"     , "dev"  , "1.2.0-dev1" , "release/1.2.0", false    , "1.1.1"          ], // <-- note that the branch name
         ["from rc"              , "1.2.0-rc1" , "dev"  , "1.2.0-dev1" , "release/1.2.0", false    , "1.2.0-rc2"      ], //     is not considered as any
         ["from release"         , "1.2.0"     , "dev"  , undefined    , "release/1.2.0", false    , "1.2.1"          ], //     sort of versioning input
+        ["from rel + HEADisTag" , "1.2.0"     , "dev"  , undefined    , "release/1.2.0", false    , undefined        ],
     ],
   },
   {
@@ -213,6 +219,7 @@ const testSuiteDefinitions = [
      // [ test description      , version     ,  bump  , latest draft , branch         , breaking?, expected version ]
         ["from dev"             , "1.1.0"     , "rc"   , "1.2.0-dev1" , "release/1.2.0", false    , "1.1.1"          ],
         ["from rc"              , "1.2.0-rc1" , "rc"   , "1.2.0-dev1" , "release/1.2.0", false    , "1.2.0-rc2"      ],
+        ["from rc + HEADisTag"  , "1.2.0-rc1" , "rc"   , "1.2.0-dev1" , "release/1.2.0", false    , undefined        ],
         ["from release"         , "1.2.0"     , "rc"   , "1.2.0-dev1" , "release/1.2.0", false    , "1.2.1"          ],
     ],
   },
@@ -233,6 +240,7 @@ const testSuiteDefinitions = [
         ["from dev"             , "1.1.0"     , "rel"  , "1.2.0-dev1" , "release/1.2.0", false    , "1.1.1"          ],
         ["from rc"              , "1.2.0-rc1" , "rel"  , "1.2.0-dev1" , "release/1.2.0", false    , "1.2.0"          ],
         ["from release"         , "1.2.0"     , "rel"  , "1.2.0-dev1" , "release/1.2.0", false    , "1.2.1"          ],
+        ["from rel + HEADisTag" , "1.2.0"     , "rel"  , undefined    , "release/1.2.0", false    , undefined        ],
     ],
   },
   // BREAKING CHANGES


### PR DESCRIPTION
When a build is re-run on a release branch while nothing has changed, that is, while HEAD still matches the latest tag, we now no longer blindly bump another RC version on top of it.
This flow is more common than one might assume, since GitHub workflows push triggers trigger on ref pushes of "empty branches", as well.