### PR TITLE
fix: do not bump dev releases with breaking changes

### DIFF
--- a/dist/bump/index.js
+++ b/dist/bump/index.js
@@ -12114,7 +12114,8 @@ function getNextSdkVer(currentVersion, sdkVerBumpType, isReleaseBranch, headMatc
             nextVersion.prerelease = "rc1";
         }
         else if (sdkVerBumpType === "dev") {
-            if (hasBreakingChange || currentIsRel || currentIsRc) {
+            // TODO: decide on how best to handle hasBreakingChange in this case
+            if (currentIsRel || currentIsRc) {
                 nextVersion = bumpWithBuildInfo(releaseBump);
                 nextVersion.prerelease = `${devPrereleaseText}1`;
             }

--- a/dist/validate/index.js
+++ b/dist/validate/index.js
@@ -12074,7 +12074,8 @@ function getNextSdkVer(currentVersion, sdkVerBumpType, isReleaseBranch, headMatc
             nextVersion.prerelease = "rc1";
         }
         else if (sdkVerBumpType === "dev") {
-            if (hasBreakingChange || currentIsRel || currentIsRc) {
+            // TODO: decide on how best to handle hasBreakingChange in this case
+            if (currentIsRel || currentIsRc) {
                 nextVersion = bumpWithBuildInfo(releaseBump);
                 nextVersion.prerelease = `${devPrereleaseText}1`;
             }

--- a/src/bump.ts
+++ b/src/bump.ts
@@ -659,7 +659,8 @@ function getNextSdkVer(
       }
       nextVersion.prerelease = "rc1";
     } else if (sdkVerBumpType === "dev") {
-      if (hasBreakingChange || currentIsRel || currentIsRc) {
+      // TODO: decide on how best to handle hasBreakingChange in this case
+      if (currentIsRel || currentIsRc) {
         nextVersion = bumpWithBuildInfo(releaseBump);
         nextVersion.prerelease = `${devPrereleaseText}1`;
       } else {

--- a/test/bump.sdkver.test.ts
+++ b/test/bump.sdkver.test.ts
@@ -241,7 +241,7 @@ const testSuiteDefinitions = [
     tests: [
      // [ test description      , version     ,  bump  , latest draft , branch         , breaking?, expected version ]
         ["main branch"          , "1.2.0"     , "dev"  , undefined    , "master"       , true    , "2.0.0-dev1"      ],
-        ["main branch, draft"   , "1.2.0"     , "dev"  , "1.3.0-dev1" , "master"       , true    , "2.0.0-dev1"      ],
+        ["main branch, draft"   , "1.2.0"     , "dev"  , "1.3.0-dev1" , "master"       , true    , "1.3.0-dev2"      ],
         ["release branch"       , "1.2.0"     , "dev"  , undefined    , "release/1.2.0", true    , undefined         ],
         ["release branch, draft", "1.2.0"     , "dev"  , "1.3.0-dev1" , "release/1.2.0", true    , undefined         ],
         ["release branch+RC"    , "1.2.0-rc1" , "dev"  , undefined    , "release/1.2.0", true    , undefined         ],


### PR DESCRIPTION
Currently, a new major range is started on `-dev` releases when breaking changes are present in the history list.
This is not always desirable, so this removes that behavior for now.