### PR TITLE
feat(sdkver): add option to automatically create release branch

### DIFF
--- a/dist/bump/index.js
+++ b/dist/bump/index.js
@@ -12260,6 +12260,36 @@ function bumpSdkVer(config, bumpInfo, releaseMode, sdkVerBumpType, headSha, bran
         if (!bumped) {
             core.info("ℹ️ No bump was performed");
         }
+        else {
+            // Create a release branch for releases and RC's if we're configured to do so
+            // and are currently not running on a release branch.
+            if (config.sdkverCreateReleaseBranches !== undefined &&
+                !isReleaseBranch &&
+                sdkVerBumpType !== "dev") {
+                const releaseBranchName = `${config.sdkverCreateReleaseBranches}${nextVersion.major}.${nextVersion.minor}`;
+                core.info(`Creating release branch ${releaseBranchName}..`);
+                try {
+                    (0, github_1.createBranch)(`refs/heads/${releaseBranchName}`, headSha);
+                }
+                catch (ex) {
+                    if (ex instanceof request_error_1.RequestError && ex.status === 422) {
+                        core.warning(`The branch '${releaseBranchName}' already exists` +
+                            `${(0, github_1.getRunNumber)() !== 1 ? " (NOTE: this is a re-run)." : "."}`);
+                    }
+                    else if (ex instanceof request_error_1.RequestError) {
+                        core.warning(`Unable to create release branch '${releaseBranchName}' due to ` +
+                            `HTTP request error (status ${ex.status}):\n${ex.message}`);
+                    }
+                    else if (ex instanceof Error) {
+                        core.warning(`Unable to create release branch '${releaseBranchName}':\n${ex.message}`);
+                    }
+                    else {
+                        core.warning(`Unknown error during ${releaseMode} creation`);
+                        throw ex;
+                    }
+                }
+            }
+        }
         core.setOutput("next-version", (_f = nextVersion === null || nextVersion === void 0 ? void 0 : nextVersion.toString()) !== null && _f !== void 0 ? _f : "");
         core.endGroup();
         return bumped;
@@ -12900,6 +12930,7 @@ const CONFIG_ITEMS = [
     "version-scheme",
     "release-branches",
     "prereleases",
+    "sdkver-create-release-branches",
 ];
 const VERSION_SCHEMES = ["semver", "sdkver"];
 /**
@@ -13063,7 +13094,7 @@ class Configuration {
                     }
                     break;
                 case "initial-development":
-                    /* Example YAML
+                    /* Example YAML:
                      *   initial-development: true
                      */
                     if (typeof data[key] === "boolean") {
@@ -13074,7 +13105,7 @@ class Configuration {
                     }
                     break;
                 case "prereleases":
-                    /* Example YAML
+                    /* Example YAML:
                      *   prereleases: ""
                      *   prereleases: "dev"
                      */
@@ -13085,7 +13116,29 @@ class Configuration {
                         throw new Error(`Incorrect type '${typeof data[key]}' for '${key}', must be '${typeof this.prereleasePrefix}'!`);
                     }
                     break;
+                case "sdkver-create-release-branches":
+                    /* Example YAML:
+                     *   sdkver-create-release-branches: true  # defaults to 'release/'
+                     *   sdkver-create-release-branches: "rel-"
+                     */
+                    if (typeof data[key] === "boolean") {
+                        this.sdkverCreateReleaseBranches = data[key]
+                            ? "release/"
+                            : undefined;
+                    }
+                    else if (typeof data[key] === "string") {
+                        this.sdkverCreateReleaseBranches = data[key];
+                    }
+                    else {
+                        throw new Error(`Incorrect type '${typeof data[key]}' for '${key}', must be either "boolean" or "string"!`);
+                    }
+                    break;
             }
+        }
+        if (this.sdkverCreateReleaseBranches !== undefined &&
+            this.versionScheme !== "sdkver") {
+            core.warning("The configuration option `sdkver-create-release-branches` is only relevant " +
+                'when the `version-scheme` is set to `"sdkver"`.');
         }
     }
     /**
@@ -13100,6 +13153,7 @@ class Configuration {
         this.prereleasePrefix = undefined;
         this.tags = DEFAULT_ACCEPTED_TAGS;
         this.rules = new Map();
+        this.sdkverCreateReleaseBranches = undefined;
         for (const rule of rules_1.ALL_RULES) {
             this.rules[rule.id] = {
                 description: rule.description,
@@ -13241,7 +13295,7 @@ var __asyncValues = (this && this.__asyncValues) || function (o) {
     function settle(resolve, reject, d, v) { Promise.resolve(v).then(function(v) { resolve({ value: v, done: d }); }, reject); }
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.getCommitsBetweenRefs = exports.currentHeadMatchesTag = exports.getContent = exports.updateLabels = exports.getAssociatedPullRequests = exports.getLatestTags = exports.getShaForTag = exports.matchTagsToCommits = exports.getReleaseConfiguration = exports.getConfig = exports.createTag = exports.updateDraftRelease = exports.getRelease = exports.createRelease = exports.getPullRequest = exports.getCommitsInPR = exports.getPullRequestTitle = exports.getPullRequestId = exports.isPullRequestEvent = void 0;
+exports.createBranch = exports.getCommitsBetweenRefs = exports.currentHeadMatchesTag = exports.getContent = exports.updateLabels = exports.getAssociatedPullRequests = exports.getLatestTags = exports.getShaForTag = exports.matchTagsToCommits = exports.getReleaseConfiguration = exports.getConfig = exports.createTag = exports.updateDraftRelease = exports.getRelease = exports.createRelease = exports.getPullRequest = exports.getCommitsInPR = exports.getPullRequestTitle = exports.getRunNumber = exports.getPullRequestId = exports.isPullRequestEvent = void 0;
 const core = __importStar(__nccwpck_require__(2186));
 const fs = __importStar(__nccwpck_require__(7147));
 const github = __importStar(__nccwpck_require__(5438));
@@ -13280,6 +13334,13 @@ function getPullRequestId() {
     return github.context.issue.number;
 }
 exports.getPullRequestId = getPullRequestId;
+/**
+ * Get GitHub run number
+ */
+function getRunNumber() {
+    return github.context.runNumber;
+}
+exports.getRunNumber = getRunNumber;
 /**
  * The current pull request's title
  */
@@ -13650,6 +13711,17 @@ function getCommitsBetweenRefs(baseRef, compRef) {
     });
 }
 exports.getCommitsBetweenRefs = getCommitsBetweenRefs;
+/**
+ * Creates a new branch named `branchName` on the provided sha
+ * @param name The name of the branch to be created
+ * @param sha The commit hash of the branch-off point
+ */
+function createBranch(name, sha) {
+    return __awaiter(this, void 0, void 0, function* () {
+        yield getOctokit().rest.git.createRef(Object.assign(Object.assign({}, github.context.repo), { ref: name.startsWith("refs/heads/") ? name : `refs/heads/${name}`, sha }));
+    });
+}
+exports.createBranch = createBranch;
 
 
 /***/ }),

--- a/dist/cli/index.js
+++ b/dist/cli/index.js
@@ -10706,6 +10706,7 @@ const CONFIG_ITEMS = [
     "version-scheme",
     "release-branches",
     "prereleases",
+    "sdkver-create-release-branches",
 ];
 const VERSION_SCHEMES = ["semver", "sdkver"];
 /**
@@ -10869,7 +10870,7 @@ class Configuration {
                     }
                     break;
                 case "initial-development":
-                    /* Example YAML
+                    /* Example YAML:
                      *   initial-development: true
                      */
                     if (typeof data[key] === "boolean") {
@@ -10880,7 +10881,7 @@ class Configuration {
                     }
                     break;
                 case "prereleases":
-                    /* Example YAML
+                    /* Example YAML:
                      *   prereleases: ""
                      *   prereleases: "dev"
                      */
@@ -10891,7 +10892,29 @@ class Configuration {
                         throw new Error(`Incorrect type '${typeof data[key]}' for '${key}', must be '${typeof this.prereleasePrefix}'!`);
                     }
                     break;
+                case "sdkver-create-release-branches":
+                    /* Example YAML:
+                     *   sdkver-create-release-branches: true  # defaults to 'release/'
+                     *   sdkver-create-release-branches: "rel-"
+                     */
+                    if (typeof data[key] === "boolean") {
+                        this.sdkverCreateReleaseBranches = data[key]
+                            ? "release/"
+                            : undefined;
+                    }
+                    else if (typeof data[key] === "string") {
+                        this.sdkverCreateReleaseBranches = data[key];
+                    }
+                    else {
+                        throw new Error(`Incorrect type '${typeof data[key]}' for '${key}', must be either "boolean" or "string"!`);
+                    }
+                    break;
             }
+        }
+        if (this.sdkverCreateReleaseBranches !== undefined &&
+            this.versionScheme !== "sdkver") {
+            core.warning("The configuration option `sdkver-create-release-branches` is only relevant " +
+                'when the `version-scheme` is set to `"sdkver"`.');
         }
     }
     /**
@@ -10906,6 +10929,7 @@ class Configuration {
         this.prereleasePrefix = undefined;
         this.tags = DEFAULT_ACCEPTED_TAGS;
         this.rules = new Map();
+        this.sdkverCreateReleaseBranches = undefined;
         for (const rule of rules_1.ALL_RULES) {
             this.rules[rule.id] = {
                 description: rule.description,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -29,6 +29,7 @@ initial-development: false  # OPTIONAL, defaults to `true`
 | `enable` | `None` | List of rules to enable as part of the checker (some rules are disabled by default) |
 | `allowed-branches` | `.*` | A regex specifying from which branch(es) releases and Git tags are allowed to be created |
 | `initial-development` | `true` | A boolean indicating that this project is still under _initial development_. During this state, any commit message containing a breaking change will result in a `MINOR` version bump. |
+| `sdkver-create-release-branches` | `false` | For SdkVer versioning scheme only: push a new branch if an RC or release build is performed on a non-release branch. If this config value is boolean `true`, the branch shall be of the form `release/N.N`. If this value is set to a string, it shall be used as the branch name prefix and appended with the major and minor release numbers, e.g. config value  `"rel/"` results in a branch named `rel/N.N`. |
 
 > :bulb: By default `commisery-action` will search for the file `.commisery.yml`. 
 You can specify a different file with the `config` input parameter.

--- a/docs/sdk-versioning.md
+++ b/docs/sdk-versioning.md
@@ -201,8 +201,9 @@ which are supported by the SdkVer, including:
 
   `.commisery.yml`:
   ```yml
-  version-scheme: "sdkver"    # Enable SdkVer strategy
-  initial-development: false  # Allow BREAKING CHANGES to update the <API> version
+  version-scheme: "sdkver"              # Enable SdkVer strategy
+  initial-development: false            # Allow BREAKING CHANGES to update the <API> version
+  sdkver-create-release-branches: true  # Push a new release branch for rel- and RC-builds on main
   ```
 
 - Add the following workflow to your repository:

--- a/src/config.ts
+++ b/src/config.ts
@@ -72,6 +72,7 @@ const CONFIG_ITEMS = [
   "version-scheme",
   "release-branches",
   "prereleases",
+  "sdkver-create-release-branches",
 ];
 
 const VERSION_SCHEMES = ["semver", "sdkver"];
@@ -105,6 +106,7 @@ export class Configuration {
   prereleasePrefix?: string = undefined;
   tags: IConfigurationRules = DEFAULT_ACCEPTED_TAGS;
   rules: Map<string, IRuleConfigItem> = new Map<string, IRuleConfigItem>();
+  sdkverCreateReleaseBranches?: string = undefined;
 
   set initialDevelopment(initialDevelopment: boolean) {
     this._initialDevelopment = initialDevelopment;
@@ -288,7 +290,7 @@ export class Configuration {
           break;
 
         case "initial-development":
-          /* Example YAML
+          /* Example YAML:
            *   initial-development: true
            */
           if (typeof data[key] === "boolean") {
@@ -303,7 +305,7 @@ export class Configuration {
           break;
 
         case "prereleases":
-          /* Example YAML
+          /* Example YAML:
            *   prereleases: ""
            *   prereleases: "dev"
            */
@@ -317,7 +319,36 @@ export class Configuration {
             );
           }
           break;
+
+        case "sdkver-create-release-branches":
+          /* Example YAML:
+           *   sdkver-create-release-branches: true  # defaults to 'release/'
+           *   sdkver-create-release-branches: "rel-"
+           */
+          if (typeof data[key] === "boolean") {
+            this.sdkverCreateReleaseBranches = data[key]
+              ? "release/"
+              : undefined;
+          } else if (typeof data[key] === "string") {
+            this.sdkverCreateReleaseBranches = data[key];
+          } else {
+            throw new Error(
+              `Incorrect type '${typeof data[
+                key
+              ]}' for '${key}', must be either "boolean" or "string"!`
+            );
+          }
+          break;
       }
+    }
+    if (
+      this.sdkverCreateReleaseBranches !== undefined &&
+      this.versionScheme !== "sdkver"
+    ) {
+      core.warning(
+        "The configuration option `sdkver-create-release-branches` is only relevant " +
+          'when the `version-scheme` is set to `"sdkver"`.'
+      );
     }
   }
 

--- a/src/github.ts
+++ b/src/github.ts
@@ -61,6 +61,13 @@ export function getPullRequestId(): number {
 }
 
 /**
+ * Get GitHub run number
+ */
+export function getRunNumber(): number {
+  return github.context.runNumber;
+}
+
+/**
  * The current pull request's title
  */
 export async function getPullRequestTitle(): Promise<string> {
@@ -539,4 +546,17 @@ export async function getCommitsBetweenRefs(
     });
 
   return githubCommitsAsICommits(resp.commits);
+}
+
+/**
+ * Creates a new branch named `branchName` on the provided sha
+ * @param name The name of the branch to be created
+ * @param sha The commit hash of the branch-off point
+ */
+export async function createBranch(name: string, sha: string): Promise<void> {
+  await getOctokit().rest.git.createRef({
+    ...github.context.repo,
+    ref: name.startsWith("refs/heads/") ? name : `refs/heads/${name}`,
+    sha,
+  });
 }

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -344,4 +344,50 @@ describe("Configurable options", () => {
       expect(config.allowedBranches).toEqual("main");
     });
   });
+
+  test("Default SdkVer create release branches", () => {
+    withConfig("", config => {
+      expect(config.sdkverCreateReleaseBranches).toBe(undefined);
+    });
+  });
+
+  test("Boolean defaults", () => {
+    withConfig(
+      "version-scheme: sdkver\nsdkver-create-release-branches: true",
+      config => {
+        expect(config.sdkverCreateReleaseBranches).toBe("release/");
+      }
+    );
+    withConfig(
+      "version-scheme: sdkver\nsdkver-create-release-branches: false",
+      config => {
+        expect(config.sdkverCreateReleaseBranches).toBe(undefined);
+      }
+    );
+  });
+
+  test("String values", () => {
+    withConfig(
+      "version-scheme: sdkver\nsdkver-create-release-branches: some-release-prefix-",
+      config => {
+        expect(config.sdkverCreateReleaseBranches).toBe("some-release-prefix-");
+      }
+    );
+  });
+
+  test("Enable SdkVer create release branches on non-SdkVer", () => {
+    // We expect a warning about this option not being useful when the version
+    // scheme is not 'sdkver'
+    jest.spyOn(core, "warning").mockImplementation(arg => {
+      expect(arg).toContain("sdkver-create-release-branches");
+      expect(arg).toContain("version-scheme");
+    });
+    withConfig(
+      "version-scheme: semver\nsdkver-create-release-branches: true",
+      config => {
+        expect(config.sdkverCreateReleaseBranches).toBe("release/");
+      }
+    );
+    expect(core.warning).toHaveBeenCalledTimes(1);
+  });
 });


### PR DESCRIPTION
Whenever an RC- or release-build is run on a non-release branch, we can now automatically push a release branch ref to the repo. The functionality, which is _disabled_ by default, can be enabled with a configuration option:
```yaml
  sdkver-create-release-branches: true
```