### PR TITLE
feat(bump): skip creation of changelog when requested

### DIFF
--- a/bump/action.yml
+++ b/bump/action.yml
@@ -52,6 +52,10 @@ inputs:
       One of ["rel", "rc", "dev"] [EXPERIMENTAL]
     default: ""
     required: false
+  create-changelog:
+    description: 'Adds changelog to the release'
+    required: false
+    default: true
   config:
     description: 'Path to the Commisery configuration file'
     required: false

--- a/src/actions/bump.ts
+++ b/src/actions/bump.ts
@@ -24,16 +24,13 @@ import {
   getVersionBumpTypeAndMessages,
   printNonCompliance,
 } from "../bump";
-import { generateChangelog } from "../changelog";
-import { ConventionalCommitMessage } from "../commit";
 import { Configuration } from "../config";
-import { getConfig, isPullRequestEvent } from "../github";
+import { getConfig } from "../github";
 import {
   IVersionBumpTypeAndMessages,
   ReleaseMode,
   SdkVerBumpType,
 } from "../interfaces";
-import { SemVer, SemVerType } from "../semver";
 
 /**
  * Bump action entrypoint
@@ -120,6 +117,8 @@ async function run(): Promise<void> {
 
     printNonCompliance(bumpInfo.processedCommits);
 
+    const createChangelog = core.getBooleanInput("create-changelog");
+
     core.info("");
     const releaseTypeInput = core.getInput("release-type");
 
@@ -136,7 +135,8 @@ async function run(): Promise<void> {
         releaseMode,
         branchName,
         context.sha,
-        isBranchAllowedToPublish
+        isBranchAllowedToPublish,
+        createChangelog
       );
     } else if (config.versionScheme === "sdkver") {
       if (!["rel", "rc", "dev", ""].includes(releaseTypeInput)) {
@@ -157,7 +157,8 @@ async function run(): Promise<void> {
         releaseType,
         context.sha,
         branchName,
-        isBranchAllowedToPublish
+        isBranchAllowedToPublish,
+        createChangelog
       );
     } else {
       throw new Error(

--- a/test/test_utils.ts
+++ b/test/test_utils.ts
@@ -71,6 +71,8 @@ export const mockGetBooleanInput = (setting, options?) => {
       return true;
     case "create-tag":
       return false;
+    case "create-changelog":
+      return true;
   }
   expect("error").toBe(`getBooleanInput("${setting}") not mocked`);
   return false;


### PR DESCRIPTION
I need to be able to suppress the default commisery changelog, as in some cases I use another tool to generate the release notes in a different format.
The current way is a bit crude, but maybe it's good enough.