### PR TITLE
fix: use prerelease field for dev commit hash and zero-pad numbers

### DIFF
--- a/dist/bump/index.js
+++ b/dist/bump/index.js
@@ -12086,7 +12086,8 @@ function getNextSdkVer(currentVersion, sdkVerBumpType, isReleaseBranch, headMatc
             if (currentIsRc) {
                 // We need to keep the pre intact (undefined), but the post needs to be
                 // cleared, as that contains the commit hash of the previous dev version.
-                nextVersion = currentVersion.nextPrerelease(undefined, "");
+                // Also zero pad to at least two digits.
+                nextVersion = currentVersion.nextPrerelease(undefined, "", 2);
                 if (!nextVersion) {
                     fatal(`Unable to bump RC version for: ${currentVersion.toString()}; ` +
                         `make sure it contains an index number.`);
@@ -12157,8 +12158,8 @@ function getNextSdkVer(currentVersion, sdkVerBumpType, isReleaseBranch, headMatc
                 nextVersion.prerelease = `${devPrereleaseText}001`;
             }
             else {
-                // Keep prefix, clear postfix
-                nextVersion = currentVersion.nextPrerelease(undefined, "");
+                // Keep prefix, clear postfix, zero pad to at least three digits
+                nextVersion = currentVersion.nextPrerelease(undefined, "", 3);
                 if (!nextVersion) {
                     // This can only happen if the current version is something
                     // unexpected and invalid, like a prerelease without a number, e.g.:
@@ -14776,18 +14777,22 @@ class SemVer {
      * Attempts to increment the first number encountered in the
      * `prerelease` field, optionally overriding string before and
      * after said number.
+     * `zeroPadToMinimum` can be provided to zero-pad the number in
+     * the `prerelease` field to the specified minimum amount of digits.
      *
      * Returns new SemVer object or `null` if unsuccessful.
      */
-    nextPrerelease(pre, post) {
+    nextPrerelease(pre, post, zeroPadToMinimum) {
         const match = /(?<pre>\D*)(?<nr>\d+)(?<post>.*)/.exec(this.prerelease);
         if (match == null || match.groups == null) {
             return null;
         }
-        // We need to keep the same amount of characters in the 'nr' group, so pad it with zeroes as needed.
+        // We need to either keep the same amount of characters in the 'nr' group, or respect the provided
+        // `zeroPadToMinimum`, so pad it with zeroes as needed.
         const incrementAndZeroPad = (inputNr) => {
+            const targetLength = Math.max(zeroPadToMinimum !== null && zeroPadToMinimum !== void 0 ? zeroPadToMinimum : 0, inputNr.length);
             let incremented = `${+inputNr + 1}`;
-            while (incremented.length < inputNr.length) {
+            while (incremented.length < targetLength) {
                 incremented = `0${incremented}`;
             }
             return incremented;

--- a/dist/bump/index.js
+++ b/dist/bump/index.js
@@ -11825,13 +11825,13 @@ function newDraftRelease(currentVersion, changelog, sha, prefix) {
     return __awaiter(this, void 0, void 0, function* () {
         // Either update went wrong or there was nothing to update
         const nextPrereleaseVersion = currentVersion.nextPatch();
+        nextPrereleaseVersion.build = currentVersion.build;
         if (prefix === "dev") {
-            nextPrereleaseVersion.build = shortSha(sha);
+            nextPrereleaseVersion.prerelease = `${prefix}001.${shortSha(sha)}`;
         }
         else {
-            nextPrereleaseVersion.build = currentVersion.build;
+            nextPrereleaseVersion.prerelease = `${prefix}001`;
         }
-        nextPrereleaseVersion.prerelease = `${prefix}1`;
         yield (0, github_1.createRelease)(nextPrereleaseVersion.toString(), sha, changelog, true, false);
         return nextPrereleaseVersion.toString();
     });
@@ -12084,7 +12084,9 @@ function getNextSdkVer(currentVersion, sdkVerBumpType, isReleaseBranch, headMatc
         else {
             // Bumps for "rc" and "dev" are identical on a release branch
             if (currentIsRc) {
-                nextVersion = currentVersion.nextPrerelease();
+                // We need to keep the pre intact (undefined), but the post needs to be
+                // cleared, as that contains the commit hash of the previous dev version.
+                nextVersion = currentVersion.nextPrerelease(undefined, "");
                 if (!nextVersion) {
                     fatal(`Unable to bump RC version for: ${currentVersion.toString()}; ` +
                         `make sure it contains an index number.`);
@@ -12146,22 +12148,23 @@ function getNextSdkVer(currentVersion, sdkVerBumpType, isReleaseBranch, headMatc
                 nextVersion = semver_1.SemVer.copy(currentVersion);
                 nextVersion.build = "";
             }
-            nextVersion.prerelease = `${RC_PREFIX}1`;
+            nextVersion.prerelease = `${RC_PREFIX}01`;
         }
         else if (sdkVerBumpType === "dev") {
             // TODO: decide on how best to handle hasBreakingChange in this case
             if (currentIsRel || currentIsRc) {
                 nextVersion = bumpOrError(releaseBump);
-                nextVersion.prerelease = `${devPrereleaseText}1`;
+                nextVersion.prerelease = `${devPrereleaseText}001`;
             }
             else {
-                nextVersion = currentVersion.nextPrerelease();
+                // Keep prefix, clear postfix
+                nextVersion = currentVersion.nextPrerelease(undefined, "");
                 if (!nextVersion) {
                     // This can only happen if the current version is something
                     // unexpected and invalid, like a prerelease without a number, e.g.:
                     //     1.2.3-rc        1.2.3-dev        1.2.3-testing
                     nextVersion = bumpOrError(semver_1.SemVerType.MINOR);
-                    nextVersion.prerelease = `${devPrereleaseText}1`;
+                    nextVersion.prerelease = `${devPrereleaseText}001`;
                     core.warning(`Failed to bump the prerelease for version ${currentVersion.toString()}` +
                         `; moving to next release version ${nextVersion.toString()}`);
                 }
@@ -12178,12 +12181,7 @@ function getNextSdkVer(currentVersion, sdkVerBumpType, isReleaseBranch, headMatc
         nextVersion.build = buildMetadata;
     }
     if (sdkVerBumpType === "dev" && !isReleaseBranch) {
-        if (nextVersion.build === "") {
-            nextVersion.build = `${shortSha(headSha)}`;
-        }
-        else {
-            nextVersion.build += `.${shortSha(headSha)}`;
-        }
+        nextVersion.prerelease += `.${shortSha(headSha)}`;
     }
     return nextVersion;
 }
@@ -14786,8 +14784,16 @@ class SemVer {
         if (match == null || match.groups == null) {
             return null;
         }
+        // We need to keep the same amount of characters in the 'nr' group, so pad it with zeroes as needed.
+        const incrementAndZeroPad = (inputNr) => {
+            let incremented = `${+inputNr + 1}`;
+            while (incremented.length < inputNr.length) {
+                incremented = `0${incremented}`;
+            }
+            return incremented;
+        };
         const nv = SemVer.copy(this);
-        nv.prerelease = `${pre !== null && pre !== void 0 ? pre : match.groups.pre}${+match.groups.nr + 1}${post !== null && post !== void 0 ? post : match.groups.post}`;
+        nv.prerelease = `${pre !== null && pre !== void 0 ? pre : match.groups.pre}${incrementAndZeroPad(match.groups.nr)}${post !== null && post !== void 0 ? post : match.groups.post}`;
         nv.build = "";
         return nv;
     }

--- a/dist/cli/index.js
+++ b/dist/cli/index.js
@@ -12020,8 +12020,16 @@ class SemVer {
         if (match == null || match.groups == null) {
             return null;
         }
+        // We need to keep the same amount of characters in the 'nr' group, so pad it with zeroes as needed.
+        const incrementAndZeroPad = (inputNr) => {
+            let incremented = `${+inputNr + 1}`;
+            while (incremented.length < inputNr.length) {
+                incremented = `0${incremented}`;
+            }
+            return incremented;
+        };
         const nv = SemVer.copy(this);
-        nv.prerelease = `${pre !== null && pre !== void 0 ? pre : match.groups.pre}${+match.groups.nr + 1}${post !== null && post !== void 0 ? post : match.groups.post}`;
+        nv.prerelease = `${pre !== null && pre !== void 0 ? pre : match.groups.pre}${incrementAndZeroPad(match.groups.nr)}${post !== null && post !== void 0 ? post : match.groups.post}`;
         nv.build = "";
         return nv;
     }

--- a/dist/cli/index.js
+++ b/dist/cli/index.js
@@ -12012,18 +12012,22 @@ class SemVer {
      * Attempts to increment the first number encountered in the
      * `prerelease` field, optionally overriding string before and
      * after said number.
+     * `zeroPadToMinimum` can be provided to zero-pad the number in
+     * the `prerelease` field to the specified minimum amount of digits.
      *
      * Returns new SemVer object or `null` if unsuccessful.
      */
-    nextPrerelease(pre, post) {
+    nextPrerelease(pre, post, zeroPadToMinimum) {
         const match = /(?<pre>\D*)(?<nr>\d+)(?<post>.*)/.exec(this.prerelease);
         if (match == null || match.groups == null) {
             return null;
         }
-        // We need to keep the same amount of characters in the 'nr' group, so pad it with zeroes as needed.
+        // We need to either keep the same amount of characters in the 'nr' group, or respect the provided
+        // `zeroPadToMinimum`, so pad it with zeroes as needed.
         const incrementAndZeroPad = (inputNr) => {
+            const targetLength = Math.max(zeroPadToMinimum !== null && zeroPadToMinimum !== void 0 ? zeroPadToMinimum : 0, inputNr.length);
             let incremented = `${+inputNr + 1}`;
-            while (incremented.length < inputNr.length) {
+            while (incremented.length < targetLength) {
                 incremented = `0${incremented}`;
             }
             return incremented;

--- a/dist/validate/index.js
+++ b/dist/validate/index.js
@@ -12045,7 +12045,8 @@ function getNextSdkVer(currentVersion, sdkVerBumpType, isReleaseBranch, headMatc
             if (currentIsRc) {
                 // We need to keep the pre intact (undefined), but the post needs to be
                 // cleared, as that contains the commit hash of the previous dev version.
-                nextVersion = currentVersion.nextPrerelease(undefined, "");
+                // Also zero pad to at least two digits.
+                nextVersion = currentVersion.nextPrerelease(undefined, "", 2);
                 if (!nextVersion) {
                     fatal(`Unable to bump RC version for: ${currentVersion.toString()}; ` +
                         `make sure it contains an index number.`);
@@ -12116,8 +12117,8 @@ function getNextSdkVer(currentVersion, sdkVerBumpType, isReleaseBranch, headMatc
                 nextVersion.prerelease = `${devPrereleaseText}001`;
             }
             else {
-                // Keep prefix, clear postfix
-                nextVersion = currentVersion.nextPrerelease(undefined, "");
+                // Keep prefix, clear postfix, zero pad to at least three digits
+                nextVersion = currentVersion.nextPrerelease(undefined, "", 3);
                 if (!nextVersion) {
                     // This can only happen if the current version is something
                     // unexpected and invalid, like a prerelease without a number, e.g.:
@@ -14735,18 +14736,22 @@ class SemVer {
      * Attempts to increment the first number encountered in the
      * `prerelease` field, optionally overriding string before and
      * after said number.
+     * `zeroPadToMinimum` can be provided to zero-pad the number in
+     * the `prerelease` field to the specified minimum amount of digits.
      *
      * Returns new SemVer object or `null` if unsuccessful.
      */
-    nextPrerelease(pre, post) {
+    nextPrerelease(pre, post, zeroPadToMinimum) {
         const match = /(?<pre>\D*)(?<nr>\d+)(?<post>.*)/.exec(this.prerelease);
         if (match == null || match.groups == null) {
             return null;
         }
-        // We need to keep the same amount of characters in the 'nr' group, so pad it with zeroes as needed.
+        // We need to either keep the same amount of characters in the 'nr' group, or respect the provided
+        // `zeroPadToMinimum`, so pad it with zeroes as needed.
         const incrementAndZeroPad = (inputNr) => {
+            const targetLength = Math.max(zeroPadToMinimum !== null && zeroPadToMinimum !== void 0 ? zeroPadToMinimum : 0, inputNr.length);
             let incremented = `${+inputNr + 1}`;
-            while (incremented.length < inputNr.length) {
+            while (incremented.length < targetLength) {
                 incremented = `0${incremented}`;
             }
             return incremented;

--- a/docs/sdk-versioning.md
+++ b/docs/sdk-versioning.md
@@ -64,12 +64,12 @@ This automatically implies that **no** git tags will be created for each Develop
 
 The below table indicates the behavior when creating a Development Release:
 
-| Current Version | Increment Type      | Next Version |
-| --------------- | ------------------- | ------------ |
-| `0.1.0`         | Non-breaking change | `0.2.0-dev1` |
-| `0.2.0-dev1`    | Non-breaking change | `0.2.0-dev2` |
-| `0.1.0`         | Breaking Change     | `1.0.0-dev1` |
-| `0.2.0-dev1`    | Breaking change     | `1.0.0-dev2` |
+| Current Version | Increment Type      | Next Version   |
+| --------------- | ------------------- | -------------- |
+| `0.1.0`         | Non-breaking change | `0.2.0-dev001` |
+| `0.2.0-dev001`  | Non-breaking change | `0.2.0-dev002` |
+| `0.1.0`         | Breaking Change     | `1.0.0-dev001` |
+| `0.2.0-dev001`  | Breaking change     | `1.0.0-dev002` |
 
 
 ### Release Candidates
@@ -87,16 +87,16 @@ A Release Candidate is initiated on the `main` development branch;
 
 | Current Version | Increment Type      | Next Version |
 | --------------- | ------------------- | ------------ |
-| `0.1.0-dev1`    | Release Candidate   | `0.1.0-rc1`  |
-| `0.1.0`         | Release Candidate   | `0.2.0-rc1`  |
-| `0.1.0-rc1`     | Release Candidate   | `0.2.0-rc1`  |
+| `0.1.0-dev001`  | Release Candidate   | `0.1.0-rc01`  |
+| `0.1.0`         | Release Candidate   | `0.2.0-rc01`  |
+| `0.1.0-rc01`    | Release Candidate   | `0.2.0-rc01`  |
 
 Stabilizing a Release Candidate is handled on a release branch (i.e. `release/0.1`);
 
 | Current Version | Increment Type      | Next Version |
 | --------------- | ------------------- | ------------ |
-| `0.1.0-rc1`     | Non-breaking change | `0.1.0-rc2`  |
-| `0.1.0-rc2`     | Breaking change     | `0.1.0-rc3`  |
+| `0.1.0-rc01`    | Non-breaking change | `0.1.0-rc02`  |
+| `0.1.0-rc02`    | Breaking change     | `0.1.0-rc03`  |
 
 ### Releases
 
@@ -108,15 +108,15 @@ You can release both Development Releases and Release Candidates from either the
 
 | Current Version | Increment Type      | Next Version |
 | --------------- | ------------------- | ------------ |
-| `0.1.0-dev1`    | Release             | `0.1.0`      |
-| `0.1.0-rc1`     | Release             | `0.1.0`      |
+| `0.1.0-dev001`  | Release             | `0.1.0`      |
+| `0.1.0-rc01`    | Release             | `0.1.0`      |
 | `0.1.0`         | Release             | `0.2.0`      |
 
 or the `release` branch:
 
 | Current Version | Increment Type      | Next Version |
 | --------------- | ------------------- | ------------ |
-| `0.1.0-rc2`     | Release             | `0.1.0`      |
+| `0.1.0-rc02`    | Release             | `0.1.0`      |
 | `0.1.0`         | Release             | `0.1.1`      |
 
 Additionally, you can introduce additional fixes on a release by adding commits on a release branch
@@ -134,36 +134,36 @@ Below you can find an example of common strategies which can be utilized using S
 
 ```mermaid
 gitGraph
-  commit id: "0.1.0-dev1"
-  commit id: "0.1.0-dev2" tag: "0.1.0"
-  commit id: "0.2.0-dev1"
-  commit id: "0.2.0-dev2" tag: "0.2.0-rc1"
+  commit id: "0.1.0-dev001"
+  commit id: "0.1.0-dev002" tag: "0.1.0"
+  commit id: "0.2.0-dev001"
+  commit id: "0.2.0-dev002" tag: "0.2.0-rc01"
   branch release/v0.2
   checkout main
-  commit id: "0.3.0-dev1"
+  commit id: "0.3.0-dev001"
   checkout release/v0.2
-  cherry-pick id: "0.3.0-dev1" tag: "0.2.0-rc2 + 0.2.0"
+  cherry-pick id: "0.3.0-dev001" tag: "0.2.0-rc02 + 0.2.0"
   checkout main
-  commit id: "0.3.0-dev2"
-  commit id: "0.3.0-dev3"
+  commit id: "0.3.0-dev002"
+  commit id: "0.3.0-dev003"
   checkout release/v0.2
-  cherry-pick id: "0.3.0-dev3" tag: "0.2.1"
+  cherry-pick id: "0.3.0-dev003" tag: "0.2.1"
   checkout main
-  commit id: "1.0.0-dev1" type: REVERSE
-  commit id: "1.0.0-dev2" tag: "1.0.0-rc1"
+  commit id: "1.0.0-dev001" type: REVERSE
+  commit id: "1.0.0-dev002" tag: "1.0.0-rc01"
   branch release/v1.0
   checkout main
-  commit id: "1.1.0-dev1"
-  commit id: "1.1.0-dev2"
+  commit id: "1.1.0-dev001"
+  commit id: "1.1.0-dev002"
   checkout release/v1.0
-  cherry-pick id: "1.1.0-dev2" tag: "1.0.0-rc2"
+  cherry-pick id: "1.1.0-dev002" tag: "1.0.0-rc02"
   checkout main
-  commit id: "1.1.0-dev3"
-  commit id: "1.1.0-dev4"
+  commit id: "1.1.0-dev003"
+  commit id: "1.1.0-dev004"
   checkout release/v1.0
-  cherry-pick id: "1.1.0-dev4" tag: "1.0.0-rc3 + 1.0.0"
+  cherry-pick id: "1.1.0-dev004" tag: "1.0.0-rc03 + 1.0.0"
   checkout main
-  commit id: "1.1.0-dev5"
+  commit id: "1.1.0-dev005"
   checkout release/v1.0
   commit id: "1.0.1" tag: "1.0.1"
 ```
@@ -267,8 +267,8 @@ $ git pull
 
 ```mermaid
 gitGraph
-  commit id: "0.1.0-dev1"
-  commit id: "0.1.0-dev2"
+  commit id: "0.1.0-dev001"
+  commit id: "0.1.0-dev002"
 ```
 
 > **NOTE**: Above example already contains few earlier Development releases (`0.1.0-devN`)
@@ -281,8 +281,8 @@ $ git checkout -b feat/build-feature
 
 ```mermaid
 gitGraph
-  commit id: "0.1.0-dev1"
-  commit id: "0.1.0-dev2"
+  commit id: "0.1.0-dev001"
+  commit id: "0.1.0-dev002"
   branch feat/build-feature
   checkout feat/build-feature
   commit id: " " type: HIGHLIGHT
@@ -303,8 +303,8 @@ $ git push
 
 ```mermaid
 gitGraph
-  commit id: "0.1.0-dev1"
-  commit id: "0.1.0-dev2"
+  commit id: "0.1.0-dev001"
+  commit id: "0.1.0-dev002"
   branch feat/build-feature
   checkout feat/build-feature
   commit id: "commit-1"
@@ -315,13 +315,13 @@ In the meantime, the `main` branch might have already advanced with additional c
 
 ```mermaid
 gitGraph
-  commit id: "0.1.0-dev1"
-  commit id: "0.1.0-dev2"
+  commit id: "0.1.0-dev001"
+  commit id: "0.1.0-dev002"
   branch feat/build-feature
   checkout feat/build-feature
   commit id: "commit-1"
   checkout main
-  commit id: "0.1.0-dev3" type: HIGHLIGHT
+  commit id: "0.1.0-dev003" type: HIGHLIGHT
   checkout feat/build-feature
   commit id: "commit-2"
 ```
@@ -341,26 +341,26 @@ $ gh pr merge --merge
 
 ```mermaid
 gitGraph
-  commit id: "0.1.0-dev1"
-  commit id: "0.1.0-dev2"
+  commit id: "0.1.0-dev001"
+  commit id: "0.1.0-dev002"
   branch feat/build-feature
   checkout feat/build-feature
   commit id: "commit-1"
   checkout main
-  commit id: "0.1.0-dev3"
+  commit id: "0.1.0-dev003"
   checkout feat/build-feature
   commit id: "commit-2"
   checkout main
-  merge feat/build-feature id: "0.1.0-dev4" type: HIGHLIGHT
+  merge feat/build-feature id: "0.1.0-dev004" type: HIGHLIGHT
 ```
 
-Once the Pull Request is merged, a new `draft` GitHub release (`v0.1.0-dev4`) will be created;
+Once the Pull Request is merged, a new `draft` GitHub release (`v0.1.0-dev004`) will be created;
 
 ```sh
 $ gh release list
 
 TITLE           TYPE    TAG NAME      PUBLISHED
-v0.1.0-dev4     Draft   v0.1.0-dev4   about 1 minute ago
+v0.1.0-dev004     Draft   v0.1.0-dev004   about 1 minute ago
 ```
 
 ## Release Candidate flow
@@ -371,18 +371,18 @@ Considering the current state:
 
 ```mermaid
 gitGraph
-  commit id: "0.1.0-dev1"
-  commit id: "0.1.0-dev2"
+  commit id: "0.1.0-dev001"
+  commit id: "0.1.0-dev002"
 
   branch feat/build-feature
   checkout feat/build-feature
   commit id: "commit-1"
   checkout main
-  commit id: "0.1.0-dev3"
+  commit id: "0.1.0-dev003"
   checkout feat/build-feature
   commit id: "commit-2"
   checkout main
-  merge feat/build-feature id: "0.1.0-dev4"
+  merge feat/build-feature id: "0.1.0-dev004"
 ```
 
 One can trigger a promotion of the latest Development Release to a Release Candidate by 
@@ -396,24 +396,24 @@ This will create a new *tagged* GitHub release with the `pre-release` flag enabl
 
 ```mermaid
 gitGraph
-  commit id: "0.1.0-dev1"
-  commit id: "0.1.0-dev2"
+  commit id: "0.1.0-dev001"
+  commit id: "0.1.0-dev002"
   branch feat/build-feature
   checkout feat/build-feature
   commit id: "commit-1"
   checkout main
-  commit id: "0.1.0-dev3"
+  commit id: "0.1.0-dev003"
   checkout feat/build-feature
   commit id: "commit-2"
   checkout main
-  merge feat/build-feature id: "0.1.0-dev4" tag: "v0.1.0-rc1" type: HIGHLIGHT
+  merge feat/build-feature id: "0.1.0-dev004" tag: "v0.1.0-rc01" type: HIGHLIGHT
 ```
 
 ```sh
 $ gh release list
 
 TITLE           TYPE          TAG NAME      PUBLISHED
-v0.1.0-rc1      Pre-release   v0.1.0-rc1    about 2 minutes ago
+v0.1.0-rc01      Pre-release   v0.1.0-rc01    about 2 minutes ago
 ```
 
 ### Hardening a Release Candidate
@@ -421,14 +421,14 @@ v0.1.0-rc1      Pre-release   v0.1.0-rc1    about 2 minutes ago
 Considering the following initial state:
 ```mermaid
 gitGraph
-  commit id: "0.1.0-dev1"
-  commit id: "0.1.0-dev2"
-  commit id: "0.1.0-dev3"
-  commit id: "0.1.0-dev4" tag: "v0.1.0-rc1"
-  commit id: "0.2.0-dev1"
-  commit id: "0.2.0-dev2"
-  commit id: "0.2.0-dev3"
-  commit id: "0.2.0-dev4"
+  commit id: "0.1.0-dev001"
+  commit id: "0.1.0-dev002"
+  commit id: "0.1.0-dev003"
+  commit id: "0.1.0-dev004" tag: "v0.1.0-rc01"
+  commit id: "0.2.0-dev001"
+  commit id: "0.2.0-dev002"
+  commit id: "0.2.0-dev003"
+  commit id: "0.2.0-dev004"
 ```
 
 In order to harden a Release Candidate, one needs to:
@@ -437,32 +437,32 @@ In order to harden a Release Candidate, one needs to:
 
 ```sh
 $ git checkout -b release/v0.1
-$ git cherry-pick 0.2.0-dev2 # NOTE: This should be the SHA of 0.2.0-dev2
+$ git cherry-pick 0.2.0-dev002 # NOTE: This should be the SHA of 0.2.0-dev002
 ```
 
 ```mermaid
 gitGraph
-  commit id: "0.1.0-dev1"
-  commit id: "0.1.0-dev2"
-  commit id: "0.1.0-dev3"
-  commit id: "0.1.0-dev4" tag: "v0.1.0-rc1"
+  commit id: "0.1.0-dev001"
+  commit id: "0.1.0-dev002"
+  commit id: "0.1.0-dev003"
+  commit id: "0.1.0-dev004" tag: "v0.1.0-rc01"
   branch release/v0.1
   checkout main
-  commit id: "0.2.0-dev1"
-  commit id: "0.2.0-dev2"
+  commit id: "0.2.0-dev001"
+  commit id: "0.2.0-dev002"
   checkout release/v0.1
-  cherry-pick id: "0.2.0-dev2" tag: "v0.1.0-rc2"
+  cherry-pick id: "0.2.0-dev002" tag: "v0.1.0-rc02"
   checkout main
-  commit id: "0.2.0-dev3"
-  commit id: "0.2.0-dev4"
+  commit id: "0.2.0-dev003"
+  commit id: "0.2.0-dev004"
 ```
 
 ```sh
 $ gh release list
 
 TITLE           TYPE          TAG NAME      PUBLISHED
-v0.1.0-rc2      Pre-release   v0.1.0-rc2    about 1 minute ago
-v0.1.0-rc1      Pre-release   v0.1.0-rc1    about 13 minutes ago
+v0.1.0-rc02      Pre-release   v0.1.0-rc02    about 1 minute ago
+v0.1.0-rc01      Pre-release   v0.1.0-rc01    about 13 minutes ago
 ```
 
 ## Release flow
@@ -473,19 +473,19 @@ Considering the following initial state:
 
 ```mermaid
 gitGraph
-  commit id: "0.1.0-dev1"
-  commit id: "0.1.0-dev2"
-  commit id: "0.1.0-dev3"
-  commit id: "0.1.0-dev4" tag: "v0.1.0-rc1"
+  commit id: "0.1.0-dev001"
+  commit id: "0.1.0-dev002"
+  commit id: "0.1.0-dev003"
+  commit id: "0.1.0-dev004" tag: "v0.1.0-rc01"
   branch release/v0.1
   checkout main
-  commit id: "0.2.0-dev1"
-  commit id: "0.2.0-dev2"
+  commit id: "0.2.0-dev001"
+  commit id: "0.2.0-dev002"
   checkout release/v0.1
-  cherry-pick id: "0.2.0-dev2" tag: "v0.1.0-rc2"
+  cherry-pick id: "0.2.0-dev002" tag: "v0.1.0-rc02"
   checkout main
-  commit id: "0.2.0-dev3"
-  commit id: "0.2.0-dev4"
+  commit id: "0.2.0-dev003"
+  commit id: "0.2.0-dev004"
 ```
 
 Running the release workflow on the release branch...
@@ -499,19 +499,19 @@ $ gh workflow run sdkver.yml --ref release/v0.1 --field releaseType=rel
 
 ```mermaid
 gitGraph
-  commit id: "0.1.0-dev1"
-  commit id: "0.1.0-dev2"
-  commit id: "0.1.0-dev3"
-  commit id: "0.1.0-dev4" tag: "v0.1.0-rc1"
+  commit id: "0.1.0-dev001"
+  commit id: "0.1.0-dev002"
+  commit id: "0.1.0-dev003"
+  commit id: "0.1.0-dev004" tag: "v0.1.0-rc01"
   branch release/v0.1
   checkout main
-  commit id: "0.2.0-dev1"
-  commit id: "0.2.0-dev2"
+  commit id: "0.2.0-dev001"
+  commit id: "0.2.0-dev002"
   checkout release/v0.1
-  cherry-pick id: "0.2.0-dev2" tag: "v0.1.0"
+  cherry-pick id: "0.2.0-dev002" tag: "v0.1.0"
   checkout main
-  commit id: "0.2.0-dev3"
-  commit id: "0.2.0-dev4"
+  commit id: "0.2.0-dev003"
+  commit id: "0.2.0-dev004"
 ```
 
 ```sh
@@ -519,8 +519,8 @@ $ gh release list
 
 TITLE           TYPE          TAG NAME      PUBLISHED
 v0.1.0          Latest        v0.1.0        about 2 minutes ago
-v0.1.0-rc2      Pre-release   v0.1.0-rc2    about 7 minute ago
-v0.1.0-rc1      Pre-release   v0.1.0-rc1    about 20 minutes ago
+v0.1.0-rc02      Pre-release   v0.1.0-rc02    about 7 minute ago
+v0.1.0-rc01      Pre-release   v0.1.0-rc01    about 20 minutes ago
 ```
 
 
@@ -533,23 +533,23 @@ $ git checkout main
 $ gh workflow run sdkver.yml --field releaseType=rel
 ```
 
-...will result in a promotion of `v0.2.0-dev4` towards a release:
+...will result in a promotion of `v0.2.0-dev004` towards a release:
 
 ```mermaid
 gitGraph
-  commit id: "0.1.0-dev1"
-  commit id: "0.1.0-dev2"
-  commit id: "0.1.0-dev3"
-  commit id: "0.1.0-dev4" tag: "v0.1.0-rc1"
+  commit id: "0.1.0-dev001"
+  commit id: "0.1.0-dev002"
+  commit id: "0.1.0-dev003"
+  commit id: "0.1.0-dev004" tag: "v0.1.0-rc01"
   branch release/v0.1
   checkout main
-  commit id: "0.2.0-dev1"
-  commit id: "0.2.0-dev2"
+  commit id: "0.2.0-dev001"
+  commit id: "0.2.0-dev002"
   checkout release/v0.1
-  cherry-pick id: "0.2.0-dev2" tag: "v0.1.0"
+  cherry-pick id: "0.2.0-dev002" tag: "v0.1.0"
   checkout main
-  commit id: "0.2.0-dev3"
-  commit id: "0.2.0-dev4" tag: "v0.2.0" type: HIGHLIGHT
+  commit id: "0.2.0-dev003"
+  commit id: "0.2.0-dev004" tag: "v0.2.0" type: HIGHLIGHT
 ```
 
 ```sh
@@ -558,8 +558,8 @@ $ gh release list
 TITLE           TYPE          TAG NAME      PUBLISHED
 v0.2.0          Latest        v0.2.0        about 3 minutes ago
 v0.1.0                        v0.1.0        about 5 minutes ago
-v0.1.0-rc2      Pre-release   v0.1.0-rc2    about 10 minute ago
-v0.1.0-rc1      Pre-release   v0.1.0-rc1    about 23 minutes ago
+v0.1.0-rc02      Pre-release   v0.1.0-rc02    about 10 minute ago
+v0.1.0-rc01      Pre-release   v0.1.0-rc01    about 23 minutes ago
 ```
 
 
@@ -570,23 +570,23 @@ in the next Release version:
 
 ```sh
 $ git checkout release/v0.1
-$ git cherry-pick 0.2.0-dev3 # NOTE: This should be the SHA of 0.2.0-dev3
+$ git cherry-pick 0.2.0-dev003 # NOTE: This should be the SHA of 0.2.0-dev003
 ```
 
 ```mermaid
 gitGraph
-  commit id: "0.1.0-dev4" tag: "v0.1.0-rc1"
+  commit id: "0.1.0-dev004" tag: "v0.1.0-rc01"
   branch release/v0.1
   checkout main
-  commit id: "0.2.0-dev1"
-  commit id: "0.2.0-dev2"
+  commit id: "0.2.0-dev001"
+  commit id: "0.2.0-dev002"
   checkout release/v0.1
-  cherry-pick id: "0.2.0-dev2" tag: "v0.1.0"
+  cherry-pick id: "0.2.0-dev002" tag: "v0.1.0"
   checkout main
-  commit id: "0.2.0-dev3"
-  commit id: "0.2.0-dev4" tag: "v0.2.0"
+  commit id: "0.2.0-dev003"
+  commit id: "0.2.0-dev004" tag: "v0.2.0"
   checkout release/v0.1
-  cherry-pick id: "0.2.0-dev3" tag: "v0.1.1"
+  cherry-pick id: "0.2.0-dev003" tag: "v0.1.1"
 ```
 
 ```sh
@@ -596,6 +596,6 @@ TITLE           TYPE          TAG NAME      PUBLISHED
 v0.1.1                        v0.1.1        about 1 minutes ago
 v0.2.0          Latest        v0.2.0        about 3 minutes ago
 v0.1.0                        v0.1.0        about 5 minutes ago
-v0.1.0-rc2      Pre-release   v0.1.0-rc2    about 10 minute ago
-v0.1.0-rc1      Pre-release   v0.1.0-rc1    about 23 minutes ago
+v0.1.0-rc02     Pre-release   v0.1.0-rc02   about 10 minute ago
+v0.1.0-rc01     Pre-release   v0.1.0-rc01   about 23 minutes ago
 ```

--- a/src/bump.ts
+++ b/src/bump.ts
@@ -642,7 +642,8 @@ function getNextSdkVer(
       if (currentIsRc) {
         // We need to keep the pre intact (undefined), but the post needs to be
         // cleared, as that contains the commit hash of the previous dev version.
-        nextVersion = currentVersion.nextPrerelease(undefined, "");
+        // Also zero pad to at least two digits.
+        nextVersion = currentVersion.nextPrerelease(undefined, "", 2);
         if (!nextVersion) {
           fatal(
             `Unable to bump RC version for: ${currentVersion.toString()}; ` +
@@ -707,8 +708,8 @@ function getNextSdkVer(
         nextVersion = bumpOrError(releaseBump);
         nextVersion.prerelease = `${devPrereleaseText}001`;
       } else {
-        // Keep prefix, clear postfix
-        nextVersion = currentVersion.nextPrerelease(undefined, "");
+        // Keep prefix, clear postfix, zero pad to at least three digits
+        nextVersion = currentVersion.nextPrerelease(undefined, "", 3);
         if (!nextVersion) {
           // This can only happen if the current version is something
           // unexpected and invalid, like a prerelease without a number, e.g.:

--- a/src/semver.ts
+++ b/src/semver.ts
@@ -160,10 +160,19 @@ export class SemVer {
       return null;
     }
 
+    // We need to keep the same amount of characters in the 'nr' group, so pad it with zeroes as needed.
+    const incrementAndZeroPad = (inputNr: string): string => {
+      let incremented = `${+inputNr + 1}`;
+      while (incremented.length < inputNr.length) {
+        incremented = `0${incremented}`;
+      }
+      return incremented;
+    };
+
     const nv = SemVer.copy(this);
-    nv.prerelease = `${pre ?? match.groups.pre}${+match.groups.nr + 1}${
-      post ?? match.groups.post
-    }`;
+    nv.prerelease = `${pre ?? match.groups.pre}${incrementAndZeroPad(
+      match.groups.nr
+    )}${post ?? match.groups.post}`;
     nv.build = "";
 
     return nv;

--- a/src/semver.ts
+++ b/src/semver.ts
@@ -151,19 +151,27 @@ export class SemVer {
    * Attempts to increment the first number encountered in the
    * `prerelease` field, optionally overriding string before and
    * after said number.
+   * `zeroPadToMinimum` can be provided to zero-pad the number in
+   * the `prerelease` field to the specified minimum amount of digits.
    *
    * Returns new SemVer object or `null` if unsuccessful.
    */
-  nextPrerelease(pre?: string, post?: string): SemVer | null {
+  nextPrerelease(
+    pre?: string,
+    post?: string,
+    zeroPadToMinimum?: number
+  ): SemVer | null {
     const match = /(?<pre>\D*)(?<nr>\d+)(?<post>.*)/.exec(this.prerelease);
     if (match == null || match.groups == null) {
       return null;
     }
 
-    // We need to keep the same amount of characters in the 'nr' group, so pad it with zeroes as needed.
+    // We need to either keep the same amount of characters in the 'nr' group, or respect the provided
+    // `zeroPadToMinimum`, so pad it with zeroes as needed.
     const incrementAndZeroPad = (inputNr: string): string => {
+      const targetLength = Math.max(zeroPadToMinimum ?? 0, inputNr.length);
       let incremented = `${+inputNr + 1}`;
-      while (incremented.length < inputNr.length) {
+      while (incremented.length < targetLength) {
         incremented = `0${incremented}`;
       }
       return incremented;

--- a/test/bump.sdkver.test.ts
+++ b/test/bump.sdkver.test.ts
@@ -189,6 +189,8 @@ const testSuiteDefinitions = [
     suite: "Dev bumps on main branch",
     tests: [
      // [ test description      , version      ,  bump  , latest draft       , branch         , breaking?, expected version ]
+        ["from dev-draft-nopad" , "1.1.0"      , "dev"  , "1.2.0-dev1+abc12" , "master"       , false    , `1.2.0-dev002.${U.HEAD_SHA_ABBREV_8}` ],
+        ["from long-pad-dev"    , "1.1.0"      , "dev"  , "1.2.0-dev00001+ab", "master"       , false    , `1.2.0-dev00002.${U.HEAD_SHA_ABBREV_8}` ],
         ["from dev-draft"       , "1.1.0"      , "dev"  , "1.2.0-dev001.123" , "master"       , false    , `1.2.0-dev002.${U.HEAD_SHA_ABBREV_8}` ],
         ["from dev"             , "1.1.0"      , "dev"  , undefined          , "master"       , false    , `1.2.0-dev001.${U.HEAD_SHA_ABBREV_8}` ],
         ["from rc"              , "1.2.0-rc01" , "dev"  , undefined          , "master"       , false    , `1.3.0-dev001.${U.HEAD_SHA_ABBREV_8}` ],
@@ -200,8 +202,9 @@ const testSuiteDefinitions = [
     tests: [
      // [ test description      , version      ,  bump  , latest draft       , branch         , breaking?, expected version ]
         ["from dev"             , "1.1.0"      , "dev"  , "1.2.0-dev001.234" , "release/1.2.0", false    , "1.1.1"          ], // <-- note that the branch name
-        ["from rc"              , "1.2.0-rc01" , "dev"  , "1.2.0-dev001.345" , "release/1.2.0", false    , "1.2.0-rc02"     ], //     is not considered as any
-        ["from release"         , "1.2.0"      , "dev"  , undefined          , "release/1.2.0", false    , "1.2.1"          ], //     sort of versioning input
+        ["from rc nopad"        , "1.2.0-rc1"  , "dev"  , "1.2.0-dev001.345" , "release/1.2.0", false    , "1.2.0-rc02"     ], //     is not considered as any
+        ["from rc"              , "1.2.0-rc01" , "dev"  , "1.2.0-dev001.345" , "release/1.2.0", false    , "1.2.0-rc02"     ], //     sort of versioning input
+        ["from release"         , "1.2.0"      , "dev"  , undefined          , "release/1.2.0", false    , "1.2.1"          ],
         ["from rel + HEADisTag" , "1.2.0"      , "dev"  , undefined          , "release/1.2.0", false    , undefined        ],
     ],
   },

--- a/test/bump.sdkver.test.ts
+++ b/test/bump.sdkver.test.ts
@@ -188,132 +188,132 @@ const testSuiteDefinitions = [
   {
     suite: "Dev bumps on main branch",
     tests: [
-     // [ test description      , version     ,  bump  , latest draft     , branch         , breaking?, expected version ]
-        ["from dev-draft"       , "1.1.0"     , "dev"  , "1.2.0-dev1+123" , "master"       , false    , `1.2.0-dev2+${U.HEAD_SHA_ABBREV_8}` ],
-        ["from dev"             , "1.1.0"     , "dev"  , undefined        , "master"       , false    , `1.2.0-dev1+${U.HEAD_SHA_ABBREV_8}` ],
-        ["from rc"              , "1.2.0-rc1" , "dev"  , undefined        , "master"       , false    , `1.3.0-dev1+${U.HEAD_SHA_ABBREV_8}` ],
-        ["from release"         , "1.2.0"     , "dev"  , undefined        , "master"       , false    , `1.3.0-dev1+${U.HEAD_SHA_ABBREV_8}` ],
+     // [ test description      , version      ,  bump  , latest draft       , branch         , breaking?, expected version ]
+        ["from dev-draft"       , "1.1.0"      , "dev"  , "1.2.0-dev001.123" , "master"       , false    , `1.2.0-dev002.${U.HEAD_SHA_ABBREV_8}` ],
+        ["from dev"             , "1.1.0"      , "dev"  , undefined          , "master"       , false    , `1.2.0-dev001.${U.HEAD_SHA_ABBREV_8}` ],
+        ["from rc"              , "1.2.0-rc01" , "dev"  , undefined          , "master"       , false    , `1.3.0-dev001.${U.HEAD_SHA_ABBREV_8}` ],
+        ["from release"         , "1.2.0"      , "dev"  , undefined          , "master"       , false    , `1.3.0-dev001.${U.HEAD_SHA_ABBREV_8}` ],
     ],
   },
   {
     suite: "Dev bumps on release branch",
     tests: [
-     // [ test description      , version     ,  bump  , latest draft     , branch         , breaking?, expected version ]
-        ["from dev"             , "1.1.0"     , "dev"  , "1.2.0-dev1+234" , "release/1.2.0", false    , "1.1.1"          ], // <-- note that the branch name
-        ["from rc"              , "1.2.0-rc1" , "dev"  , "1.2.0-dev1+345" , "release/1.2.0", false    , "1.2.0-rc2"      ], //     is not considered as any
-        ["from release"         , "1.2.0"     , "dev"  , undefined        , "release/1.2.0", false    , "1.2.1"          ], //     sort of versioning input
-        ["from rel + HEADisTag" , "1.2.0"     , "dev"  , undefined        , "release/1.2.0", false    , undefined        ],
+     // [ test description      , version      ,  bump  , latest draft       , branch         , breaking?, expected version ]
+        ["from dev"             , "1.1.0"      , "dev"  , "1.2.0-dev001.234" , "release/1.2.0", false    , "1.1.1"          ], // <-- note that the branch name
+        ["from rc"              , "1.2.0-rc01" , "dev"  , "1.2.0-dev001.345" , "release/1.2.0", false    , "1.2.0-rc02"     ], //     is not considered as any
+        ["from release"         , "1.2.0"      , "dev"  , undefined          , "release/1.2.0", false    , "1.2.1"          ], //     sort of versioning input
+        ["from rel + HEADisTag" , "1.2.0"      , "dev"  , undefined          , "release/1.2.0", false    , undefined        ],
     ],
   },
   {
     suite: "Release candidate bumps on main branch",
     tests: [
-     // [ test description      , version     ,  bump  , latest draft     , branch           , breaking?, expected version ]  //     may be non-intuitive; rc
-        ["from dev"             , "1.1.0"     , "rc"   , "1.2.0-dev1+1"   , "master"         , false    , "1.2.0-rc1"      ], //     increments only happen on
-        ["from rc"              , "1.2.0-rc1" , "rc"   , "1.2.0-dev1+2"   , "master"         , false    , "1.3.0-rc1"      ], // <-- rel. branches, so this is
-        ["from release"         , "1.2.0"     , "rc"   , "1.2.0-dev1+3"   , "master"         , false    , "1.3.0-rc1"      ], //     the _next_ release
+     // [ test description      , version      ,  bump  , latest draft       , branch           , breaking?, expected version ]  //     may be non-intuitive; rc
+        ["from dev"             , "1.1.0"      , "rc"   , "1.2.0-dev001.1"   , "master"         , false    , "1.2.0-rc01"     ], //     increments only happen on
+        ["from rc"              , "1.2.0-rc01" , "rc"   , "1.2.0-dev001.2"   , "master"         , false    , "1.3.0-rc01"     ], // <-- rel. branches, so this is
+        ["from release"         , "1.2.0"      , "rc"   , "1.2.0-dev001.3"   , "master"         , false    , "1.3.0-rc01"     ], //     the _next_ release
     ],
   },
   {
     suite: "Release candidate bumps on release branch",
     tests: [
-     // [ test description      , version     ,  bump  , latest draft     , branch         , breaking?, expected version ]
-        ["from dev"             , "1.1.0"     , "rc"   , "1.2.0-dev1+1"   , "release/1.2.0", false    , "1.1.1"          ],
-        ["from rc"              , "1.2.0-rc1" , "rc"   , "1.2.0-dev1+2"   , "release/1.2.0", false    , "1.2.0-rc2"      ],
-        ["from rc + HEADisTag"  , "1.2.0-rc1" , "rc"   , "1.2.0-dev1+3"   , "release/1.2.0", false    , undefined        ],
-        ["from release"         , "1.2.0"     , "rc"   , "1.2.0-dev1+4"   , "release/1.2.0", false    , "1.2.1"          ],
+     // [ test description      , version      ,  bump  , latest draft       , branch         , breaking?, expected version ]
+        ["from dev"             , "1.1.0"      , "rc"   , "1.2.0-dev001.1"   , "release/1.2.0", false    , "1.1.1"          ],
+        ["from rc"              , "1.2.0-rc01" , "rc"   , "1.2.0-dev001.2"   , "release/1.2.0", false    , "1.2.0-rc02"     ],
+        ["from rc + HEADisTag"  , "1.2.0-rc01" , "rc"   , "1.2.0-dev001.3"   , "release/1.2.0", false    , undefined        ],
+        ["from release"         , "1.2.0"      , "rc"   , "1.2.0-dev001.4"   , "release/1.2.0", false    , "1.2.1"          ],
     ],
   },
   {
     suite: "Release bumps on main branch",
     tests: [
-     // [ test description      , version     ,  bump  , latest draft     , branch         , breaking?, expected version ]
-        ["from dev"             , "1.1.0"     , "rel"  , "1.2.0-dev1+1"   , "master"       , false    , "1.2.0"          ],
-        ["from rc + HEADisTag"  , "1.2.0-rc1" , "rel"  , "1.2.0-dev1+1"   , "master"       , false    , "1.2.0"          ], // note that "HEADisTag" triggers specialized behavior
-        ["from rc + HEADisnoTag", "1.2.0-rc1" , "rel"  , "1.2.0-dev1+1"   , "master"       , false    , "1.3.0"          ],
-        ["from release"         , "1.2.0"     , "rel"  , "1.2.0-dev1+1"   , "master"       , false    , "1.3.0"          ],
+     // [ test description      , version      ,  bump  , latest draft     , branch         , breaking?, expected version ]
+        ["from dev"             , "1.1.0"      , "rel"  , "1.2.0-dev001.1"   , "master"       , false    , "1.2.0"        ],
+        ["from rc + HEADisTag"  , "1.2.0-rc01" , "rel"  , "1.2.0-dev001.1"   , "master"       , false    , "1.2.0"        ], // note that "HEADisTag" triggers specialized behavior
+        ["from rc + HEADisnoTag", "1.2.0-rc01" , "rel"  , "1.2.0-dev001.1"   , "master"       , false    , "1.3.0"        ],
+        ["from release"         , "1.2.0"      , "rel"  , "1.2.0-dev001.1"   , "master"       , false    , "1.3.0"        ],
     ],
   },
   {
     suite: "Release bumps on release branch",
     tests: [
-     // [ test description      , version     ,  bump  , latest draft     , branch         , breaking?, expected version ]
-        ["from dev"             , "1.1.0"     , "rel"  , "1.2.0-dev1+1"   , "release/1.2.0", false    , "1.1.1"          ],
-        ["from rc"              , "1.2.0-rc1" , "rel"  , "1.2.0-dev1+1"   , "release/1.2.0", false    , "1.2.0"          ],
-        ["from release"         , "1.2.0"     , "rel"  , "1.2.0-dev1+1"   , "release/1.2.0", false    , "1.2.1"          ],
-        ["from rel + HEADisTag" , "1.2.0"     , "rel"  , undefined        , "release/1.2.0", false    , undefined        ],
+     // [ test description      , version      ,  bump  , latest draft     , branch         , breaking?, expected version ]
+        ["from dev"             , "1.1.0"      , "rel"  , "1.2.0-dev001.1" , "release/1.2.0", false    , "1.1.1"          ],
+        ["from rc"              , "1.2.0-rc01" , "rel"  , "1.2.0-dev001.1" , "release/1.2.0", false    , "1.2.0"          ],
+        ["from release"         , "1.2.0"      , "rel"  , "1.2.0-dev001.1" , "release/1.2.0", false    , "1.2.1"          ],
+        ["from rel + HEADisTag" , "1.2.0"      , "rel"  , undefined        , "release/1.2.0", false    , undefined        ],
     ],
   },
   // BREAKING CHANGES
   {
     suite: "Dev bumps with breaking changes",
     tests: [
-     // [ test description      , version     ,  bump  , latest draft     , branch         , breaking?, expected version ]
-        ["main branch"          , "1.2.0"     , "dev"  , undefined        , "master"       , true    , `2.0.0-dev1+${U.HEAD_SHA_ABBREV_8}` ],
-        ["main branch, draft"   , "1.2.0"     , "dev"  , "1.3.0-dev1+2"   , "master"       , true    , `1.3.0-dev2+${U.HEAD_SHA_ABBREV_8}` ],
-        ["release branch"       , "1.2.0"     , "dev"  , undefined        , "release/1.2.0", true    , undefined         ],
-        ["release branch, draft", "1.2.0"     , "dev"  , "1.3.0-dev1+3"   , "release/1.2.0", true    , undefined         ],
-        ["release branch+RC"    , "1.2.0-rc1" , "dev"  , undefined        , "release/1.2.0", true    , undefined         ],
-        ["rel branch+RC, draft" , "1.2.0-rc1" , "dev"  , "1.3.0-dev1+3"   , "release/1.2.0", true    , undefined         ],
+     // [ test description      , version      ,  bump  , latest draft     , branch         , breaking?, expected version ]
+        ["main branch"          , "1.2.0"      , "dev"  , undefined        , "master"       , true    , `2.0.0-dev001.${U.HEAD_SHA_ABBREV_8}` ],
+        ["main branch, draft"   , "1.2.0"      , "dev"  , "1.3.0-dev001.2" , "master"       , true    , `1.3.0-dev002.${U.HEAD_SHA_ABBREV_8}` ],
+        ["release branch"       , "1.2.0"      , "dev"  , undefined        , "release/1.2.0", true    , undefined         ],
+        ["release branch, draft", "1.2.0"      , "dev"  , "1.3.0-dev001.3" , "release/1.2.0", true    , undefined         ],
+        ["release branch+RC"    , "1.2.0-rc01" , "dev"  , undefined        , "release/1.2.0", true    , undefined         ],
+        ["rel branch+RC, draft" , "1.2.0-rc01" , "dev"  , "1.3.0-dev001.3" , "release/1.2.0", true    , undefined         ],
     ],
   },
   {
     suite: "Rc bumps with breaking changes",
     tests: [
-     // [ test description      , version     ,  bump  , latest draft , branch         , breaking?, expected version ]
-        ["main branch"          , "1.2.0"     , "rc"   , undefined    , "master"       , true    , "2.0.0-rc1"       ],
-        ["main branch+RC"       , "1.2.0-rc1" , "rc"   , undefined    , "master"       , true    , "2.0.0-rc1"       ],
-        ["release branch"       , "1.2.0"     , "rc"   , undefined    , "release/1.2.0", true    , undefined         ],
-        ["release branch+RC"    , "1.2.0-rc1" , "rc"   , undefined    , "release/1.2.0", true    , undefined         ],
-        ["RB+ RC for next major", "2.0.0-rc1" , "dev"  , undefined    , "release/2.0.0", true    , "2.0.0-rc2"       ],
+     // [ test description      , version      ,  bump  , latest draft , branch         , breaking?, expected version ]
+        ["main branch"          , "1.2.0"      , "rc"   , undefined    , "master"       , true    , "2.0.0-rc01"      ],
+        ["main branch+RC"       , "1.2.0-rc01" , "rc"   , undefined    , "master"       , true    , "2.0.0-rc01"      ],
+        ["release branch"       , "1.2.0"      , "rc"   , undefined    , "release/1.2.0", true    , undefined         ],
+        ["release branch+RC"    , "1.2.0-rc01" , "rc"   , undefined    , "release/1.2.0", true    , undefined         ],
+        ["RB+ RC for next major", "2.0.0-rc01" , "dev"  , undefined    , "release/2.0.0", true    , "2.0.0-rc02"      ],
     ],
   },
   {
     suite: "Release bumps with breaking changes",
     tests: [
-     // [ test description      , version     ,  bump  , latest draft , branch         , breaking?, expected version ]
-        ["main branch"          , "1.2.0"     , "rel"  , undefined    , "master"       , true    , "2.0.0"           ],
-        ["release branch"       , "1.2.0"     , "rel"  , undefined    , "release/1.2.0", true    , undefined         ],
-        ["release branch+RC"    , "1.2.0-rc1" , "rel"  , undefined    , "release/1.2.0", true    , undefined         ],
+     // [ test description      , version      ,  bump  , latest draft , branch         , breaking?, expected version ]
+        ["main branch"          , "1.2.0"      , "rel"  , undefined    , "master"       , true    , "2.0.0"           ],
+        ["release branch"       , "1.2.0"      , "rel"  , undefined    , "release/1.2.0", true    , undefined         ],
+        ["release branch+RC"    , "1.2.0-rc01" , "rel"  , undefined    , "release/1.2.0", true    , undefined         ],
     ],
   },
   // DRAFT RELEASE HANDLING
   {
     suite: "Dev bumps considers draft releases",
     tests: [
-     // [ test description      , version     ,  bump  , latest draft , branch         , breaking?, expected version ]
-        ["no draft"             , "1.2.0"     , "dev"  , undefined    , "master"       , false    , `1.3.0-dev1+${U.HEAD_SHA_ABBREV_8}`  ],
-        ["previous version"     , "1.2.0"     , "dev"  , "1.1.0-dev34", "master"       , false    , `1.3.0-dev1+${U.HEAD_SHA_ABBREV_8}`  ],
-        ["current version"      , "1.2.0"     , "dev"  , "1.2.0-dev23", "master"       , false    , `1.3.0-dev1+${U.HEAD_SHA_ABBREV_8}`  ],
-        ["next version"         , "1.2.0"     , "dev"  , "1.3.0-dev19", "master"       , false    , `1.3.0-dev20+${U.HEAD_SHA_ABBREV_8}` ],
-        ["next major"           , "1.2.0"     , "dev"  , "2.0.0-dev11", "master"       , false    , `2.0.0-dev12+${U.HEAD_SHA_ABBREV_8}` ],
+     // [ test description      , version     ,  bump  , latest draft , branch          , breaking?, expected version ]
+        ["no draft"             , "1.2.0"     , "dev"  , undefined    , "master"        , false    , `1.3.0-dev001.${U.HEAD_SHA_ABBREV_8}` ],
+        ["previous version"     , "1.2.0"     , "dev"  , "1.1.0-dev034", "master"       , false    , `1.3.0-dev001.${U.HEAD_SHA_ABBREV_8}` ],
+        ["current version"      , "1.2.0"     , "dev"  , "1.2.0-dev023", "master"       , false    , `1.3.0-dev001.${U.HEAD_SHA_ABBREV_8}` ],
+        ["next version"         , "1.2.0"     , "dev"  , "1.3.0-dev019", "master"       , false    , `1.3.0-dev020.${U.HEAD_SHA_ABBREV_8}` ],
+        ["next major"           , "1.2.0"     , "dev"  , "2.0.0-dev011", "master"       , false    , `2.0.0-dev012.${U.HEAD_SHA_ABBREV_8}` ],
     ],
   },
   {
     suite: "Release candidate bumps ignore draft releases",
     tests: [
-     // [ test description      , version     ,  bump  , latest draft , branch         , breaking?, expected version ]
-        ["mb: no draft"         , "1.2.0"     , "rc"   , undefined    , "master"       , false    , "1.3.0-rc1"      ],
-        ["mb: previous version" , "1.2.0"     , "rc"   , "1.1.0-dev34", "master"       , true     , "2.0.0-rc1"      ],
-        ["mb: current version"  , "1.2.0"     , "rc"   , "1.2.0-dev23", "master"       , false    , "1.3.0-rc1"      ], 
-        ["mb: next version"     , "1.2.0"     , "rc"   , "1.3.0-dev19", "master"       , false    , "1.3.0-rc1"      ],
-        ["rb: no draft"         , "1.2.0"     , "rc"   , undefined    , "release/1.2.0", false    , "1.2.1"          ],
-        ["rb: previous version" , "1.2.0"     , "rc"   , "1.1.0-dev34", "release/1.2.0", false    , "1.2.1"          ],
-        ["rb: current version"  , "1.2.0"     , "rc"   , "1.2.0-dev23", "release/1.2.0", false    , "1.2.1"          ],
-        ["rb: next version"     , "1.2.0"     , "rc"   , "1.3.0-dev19", "release/1.2.0", false    , "1.2.1"          ],
+     // [ test description      , version     ,  bump  , latest draft  , branch         , breaking?, expected version ]
+        ["mb: no draft"         , "1.2.0"     , "rc"   , undefined     , "master"       , false    , "1.3.0-rc01"     ],
+        ["mb: previous version" , "1.2.0"     , "rc"   , "1.1.0-dev034", "master"       , true     , "2.0.0-rc01"     ],
+        ["mb: current version"  , "1.2.0"     , "rc"   , "1.2.0-dev023", "master"       , false    , "1.3.0-rc01"     ], 
+        ["mb: next version"     , "1.2.0"     , "rc"   , "1.3.0-dev019", "master"       , false    , "1.3.0-rc01"     ],
+        ["rb: no draft"         , "1.2.0"     , "rc"   , undefined     , "release/1.2.0", false    , "1.2.1"          ],
+        ["rb: previous version" , "1.2.0"     , "rc"   , "1.1.0-dev034", "release/1.2.0", false    , "1.2.1"          ],
+        ["rb: current version"  , "1.2.0"     , "rc"   , "1.2.0-dev023", "release/1.2.0", false    , "1.2.1"          ],
+        ["rb: next version"     , "1.2.0"     , "rc"   , "1.3.0-dev019", "release/1.2.0", false    , "1.2.1"          ],
     ],
   },
   // MISCELLANEOUS ERRORS
   {
     suite: "Erroneous situations",
     tests: [
-     // [ test description      , version       ,  bump  , latest draft   , branch         , breaking?, expected version ]
-        ["rel branch major bump", "1.2.0"       , "dev"  , undefined      , "release/1.2.0", true    , undefined         ],
-        ["rel branch cur dev"   , `1.1.0-dev8+1`, "dev"  , "1.2.0-dev1+1" , "release/1.2.0", false   , undefined         ],
-        ["incorrect prerelease" , `1.1.0-devs+2`, "dev"  , undefined      , "master"       , false   , `1.2.0-dev1+${U.HEAD_SHA_ABBREV_8}` ],
-        ["wrong bump input"     , `1.1.0-dev1+3`, "beep" , undefined      , "master"       , false   , undefined         ],
-        ["unauth'd branch dev"  , `1.1.0-dev1+4`, "dev"  , undefined      , "mister"       , false   , `1.1.0-dev2+${U.HEAD_SHA_ABBREV_8}` ], // <-- TODO: make fail; not
-        ["unauth'd branch rc"   , `1.1.0-dev1+5`, "rc"   , undefined      , "mister"       , false   , "1.1.0-rc1"       ],                   // <--       implemented yet
+     // [ test description      , version         ,  bump  , latest draft     , branch         , breaking?, expected version ]
+        ["rel branch major bump", "1.2.0"         , "dev"  , undefined        , "release/1.2.0", true    , undefined         ],
+        ["rel branch cur dev"   , `1.1.0-dev008.1`, "dev"  , "1.2.0-dev001+1" , "release/1.2.0", false   , undefined         ],
+        ["incorrect prerelease" , `1.1.0-devs`    , "dev"  , undefined        , "master"       , false   , `1.2.0-dev001.${U.HEAD_SHA_ABBREV_8}` ],
+        ["wrong bump input"     , `1.1.0-dev001.3`, "beep" , undefined        , "master"       , false   , undefined         ],
+        ["unauth'd branch dev"  , `1.1.0-dev001.4`, "dev"  , undefined        , "mister"       , false   , `1.1.0-dev002.${U.HEAD_SHA_ABBREV_8}` ], // <-- TODO: make fail; not
+        ["unauth'd branch rc"   , `1.1.0-dev001.5`, "rc"   , undefined        , "mister"       , false   , "1.1.0-rc01"      ],                     // <--       implemented yet
     ],
   },
 ];

--- a/test/semver.test.ts
+++ b/test/semver.test.ts
@@ -114,6 +114,7 @@ describe("Semantic Version bumping by type", () => {
       new SemVer({ major: 1, minor: 2, patch: 4, prefix: "v" })
     );
   });
+
   test("No bump", () => {
     expect(SemVer.fromString("v1.2.3")?.bump(SemVerType.NONE)).toStrictEqual(
       null
@@ -174,6 +175,35 @@ describe("Semantic Version bumping by type (end of initial development)", () => 
     expect(
       SemVer.fromString("v0.2.3")?.bump(SemVerType.NONE, false)
     ).toStrictEqual(new SemVer({ major: 1, minor: 0, patch: 0, prefix: "v" }));
+  });
+});
+
+describe("Semantic Version prerelase incrementing", () => {
+  test("Next prerelease", () => {
+    expect(SemVer.fromString("1.2.3-9")?.nextPrerelease()).toStrictEqual(
+      new SemVer({ major: 1, minor: 2, patch: 3, prerelease: "10" })
+    );
+  });
+  test("Next prerelease, zero padded", () => {
+    expect(SemVer.fromString("1.2.3-00004")?.nextPrerelease()).toStrictEqual(
+      new SemVer({ major: 1, minor: 2, patch: 3, prerelease: "00005" })
+    );
+  });
+  test("Next prerelease, no prerelease", () => {
+    expect(SemVer.fromString("1.2.3")?.nextPrerelease()).toBeNull();
+  });
+  test("Next prerelease, prefix", () => {
+    expect(
+      SemVer.fromString("this-is-version-1.2.3-09")?.nextPrerelease()
+    ).toStrictEqual(
+      new SemVer({
+        major: 1,
+        minor: 2,
+        patch: 3,
+        prefix: "this-is-version-",
+        prerelease: "10",
+      })
+    );
   });
 });
 


### PR DESCRIPTION
This solves two issues in SdkVer:
 - Since Maven/Gradle has issues with the build info `+` in the version
   string, move the commit hash information the prerelease field.

 - Dev- and RC-releases are interpreted lexically, so zero-pad them to
   avoid e.g.: `0.1.2-dev9 > 0.1.2-dev10`
   Dev releases are padded to THREE characters, while RC releases are
   padded to TWO characters.