### PR TITLE
chore: no longer execute prettier twice over all files

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
     "build:validate": "ncc build -o dist/validate src/actions/validate.ts",
     "build:bump": "ncc build -o dist/bump src/actions/bump.ts",
     "test": "jest",
-    "lint": "eslint src/**/*.ts",
-    "format": "prettier --write **/*.ts && prettier --write **/**/*.ts",
+    "lint": "eslint **/*.ts --quiet",
+    "format": "prettier --write **/*.ts",
     "package": "pkg ."
   },
   "repository": {


### PR DESCRIPTION
The `**` glob pattern will recursively list all subfolders.