### PR TITLE
feat: commisery-action support runs triggered by merge_group event

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,13 +25,14 @@ The `commisery-action` supports a configuration file, allowing you to:
 Please refer to the [documentation](docs/configuration.md) for more details
 
 ### Conventional Commit message validation
-The following example workflow will trigger on pull request creation/modification and verify
-all associated commit messages.
+The following example workflow will trigger on pull request creation/modification,
+and on the merge queue run, and verify all associated commit messages.
 
 ```yaml
 name: Commisery
 on:
   pull_request:
+  merge_group:
 
 jobs:
   commit-message:

--- a/dist/bump/index.js
+++ b/dist/bump/index.js
@@ -35478,7 +35478,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
     return result;
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.createBranch = exports.getCommitsBetweenRefs = exports.currentHeadMatchesTag = exports.getContent = exports.updateLabels = exports.getAssociatedPullRequests = exports.getLatestTags = exports.getShaForTag = exports.matchTagsToCommits = exports.getReleaseConfiguration = exports.getConfig = exports.createTag = exports.updateDraftRelease = exports.getRelease = exports.createRelease = exports.getPullRequest = exports.getCommitsInPR = exports.getPullRequestTitle = exports.getRunNumber = exports.getPullRequestId = exports.isPullRequestEvent = void 0;
+exports.createBranch = exports.getCommitsBetweenRefs = exports.currentHeadMatchesTag = exports.getContent = exports.updateLabels = exports.getAssociatedPullRequests = exports.getLatestTags = exports.getShaForTag = exports.matchTagsToCommits = exports.getReleaseConfiguration = exports.getConfig = exports.createTag = exports.updateDraftRelease = exports.getRelease = exports.createRelease = exports.getPullRequest = exports.getCommitsInPR = exports.getPullRequestTitle = exports.getRunNumber = exports.getPullRequestId = exports.isPullRequestEvent = exports.isMergeGroupEvent = void 0;
 const core = __importStar(__nccwpck_require__(2186));
 const fs = __importStar(__nccwpck_require__(7147));
 const github = __importStar(__nccwpck_require__(5438));
@@ -35503,6 +35503,13 @@ function githubCommitsAsICommits(commits) {
         };
     });
 }
+/**
+ * Returns whether we are running in context of a Merge Group event
+ */
+function isMergeGroupEvent() {
+    return github.context.eventName === "merge_group";
+}
+exports.isMergeGroupEvent = isMergeGroupEvent;
 /**
  * Returns whether we are running in context of a Pull Request event
  */

--- a/dist/validate/index.js
+++ b/dist/validate/index.js
@@ -33673,8 +33673,8 @@ async function determineLabels(conventionalCommits, config) {
  */
 async function run() {
     try {
-        if (!(0, github_1.isPullRequestEvent)()) {
-            core.warning("Conventional Commit Message validation requires a workflow using the `pull_request` trigger!");
+        if (!(0, github_1.isPullRequestEvent)() && !(0, github_1.isMergeGroupEvent)()) {
+            core.warning("Conventional Commit Message validation requires a workflow using the `pull_request` or `merge_group` trigger!");
             return;
         }
         await (0, github_1.getConfig)(core.getInput("config"));
@@ -35436,7 +35436,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
     return result;
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.createBranch = exports.getCommitsBetweenRefs = exports.currentHeadMatchesTag = exports.getContent = exports.updateLabels = exports.getAssociatedPullRequests = exports.getLatestTags = exports.getShaForTag = exports.matchTagsToCommits = exports.getReleaseConfiguration = exports.getConfig = exports.createTag = exports.updateDraftRelease = exports.getRelease = exports.createRelease = exports.getPullRequest = exports.getCommitsInPR = exports.getPullRequestTitle = exports.getRunNumber = exports.getPullRequestId = exports.isPullRequestEvent = void 0;
+exports.createBranch = exports.getCommitsBetweenRefs = exports.currentHeadMatchesTag = exports.getContent = exports.updateLabels = exports.getAssociatedPullRequests = exports.getLatestTags = exports.getShaForTag = exports.matchTagsToCommits = exports.getReleaseConfiguration = exports.getConfig = exports.createTag = exports.updateDraftRelease = exports.getRelease = exports.createRelease = exports.getPullRequest = exports.getCommitsInPR = exports.getPullRequestTitle = exports.getRunNumber = exports.getPullRequestId = exports.isPullRequestEvent = exports.isMergeGroupEvent = void 0;
 const core = __importStar(__nccwpck_require__(2186));
 const fs = __importStar(__nccwpck_require__(7147));
 const github = __importStar(__nccwpck_require__(5438));
@@ -35461,6 +35461,13 @@ function githubCommitsAsICommits(commits) {
         };
     });
 }
+/**
+ * Returns whether we are running in context of a Merge Group event
+ */
+function isMergeGroupEvent() {
+    return github.context.eventName === "merge_group";
+}
+exports.isMergeGroupEvent = isMergeGroupEvent;
 /**
  * Returns whether we are running in context of a Pull Request event
  */

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "@tsconfig/node20": "^20.1.2",
         "@types/dedent": "^0.7.0",
         "@types/difflib": "^0.2.6",
-        "@types/jest": "^29.4.0",
+        "@types/jest": "^29.5.12",
         "@types/node": "^20",
         "@typescript-eslint/eslint-plugin": "^6.0.0",
         "@typescript-eslint/parser": "^6.0.0",
@@ -1785,9 +1785,9 @@
       }
     },
     "node_modules/@types/jest": {
-      "version": "29.5.11",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.11.tgz",
-      "integrity": "sha512-S2mHmYIVe13vrm6q4kN6fLYYAka15ALQki/vgDC3mIukEOx8WJlv0kQPM+d4w8Gp6u0uSdKND04IlTXBv0rwnQ==",
+      "version": "29.5.12",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.12.tgz",
+      "integrity": "sha512-eDC8bTvT/QhYdxJAulQikueigY5AsdBRH2yDKW3yveW7svY3+DzN84/2NUgkw10RTiJbWqZrTtoGVdYlvFJdLw==",
       "dev": true,
       "dependencies": {
         "expect": "^29.0.0",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@tsconfig/node20": "^20.1.2",
     "@types/dedent": "^0.7.0",
     "@types/difflib": "^0.2.6",
-    "@types/jest": "^29.4.0",
+    "@types/jest": "^29.5.12",
     "@types/node": "^20",
     "@typescript-eslint/eslint-plugin": "^6.0.0",
     "@typescript-eslint/parser": "^6.0.0",

--- a/src/actions/validate.ts
+++ b/src/actions/validate.ts
@@ -19,7 +19,12 @@ import { getVersionBumpType } from "../bump";
 import { ConventionalCommitMessage } from "../commit";
 
 import { Configuration } from "../config";
-import { getConfig, isPullRequestEvent, updateLabels } from "../github";
+import {
+  getConfig,
+  isMergeGroupEvent,
+  isPullRequestEvent,
+  updateLabels
+} from "../github";
 import * as Label from "../label";
 import { SemVerType } from "../semver";
 import {
@@ -59,9 +64,9 @@ async function determineLabels(
  */
 export async function run(): Promise<void> {
   try {
-    if (!isPullRequestEvent()) {
+    if (!isPullRequestEvent() && !isMergeGroupEvent()) {
       core.warning(
-        "Conventional Commit Message validation requires a workflow using the `pull_request` trigger!"
+        "Conventional Commit Message validation requires a workflow using the `pull_request` or `merge_group` trigger!"
       );
       return;
     }

--- a/src/github.ts
+++ b/src/github.ts
@@ -47,6 +47,13 @@ function githubCommitsAsICommits(
 }
 
 /**
+ * Returns whether we are running in context of a Merge Group event
+ */
+export function isMergeGroupEvent(): boolean {
+  return github.context.eventName === "merge_group";
+}
+
+/**
  * Returns whether we are running in context of a Pull Request event
  */
 export function isPullRequestEvent(): boolean {

--- a/test/validate.test.ts
+++ b/test/validate.test.ts
@@ -125,6 +125,52 @@ describe("Warning cases", () => {
   );
 });
 
+describe("Event type cases", () => {
+  const eventTypeCases = [
+    {
+      testDescription:
+        "should issue a warning if not `pull_request` nor `merge_group` trigger",
+      warningMessages: [
+        "Conventional Commit Message validation requires a workflow using the `pull_request` or `merge_group` trigger!",
+      ],
+      isPullRequest: false,
+      isMergeGroup: false,
+    },
+    {
+      testDescription: "should not issue a warning if `pull_request` trigger",
+      warningMessages: [],
+      isPullRequest: true,
+      isMergeGroup: false,
+    },
+    {
+      testDescription: "should not issue a warning if `merge_group` trigger",
+      warningMessages: [],
+      isPullRequest: false,
+      isMergeGroup: true,
+    },
+  ];
+  test.each(eventTypeCases)(
+    "$testDescription",
+    ({ testDescription, warningMessages, isPullRequest, isMergeGroup }) => {
+      jest.spyOn(github, "isPullRequestEvent").mockReturnValue(isPullRequest);
+      jest.spyOn(github, "isMergeGroupEvent").mockReturnValue(isMergeGroup);
+
+      validate.run().then(() => {
+        if (!warningMessages.length) {
+          expect(core.warning).not.toHaveBeenCalled();
+        } else {
+          expect(core.warning).toHaveBeenCalled();
+          for (const msg of warningMessages) {
+            expect(core.warning).toHaveBeenCalledWith(
+              expect.stringContaining(msg)
+            );
+          }
+        }
+      });
+    }
+  );
+});
+
 describe("Error cases", () => {
   const INVALID_CONVENTIONAL_COMMIT_MSG = "not valid Conventional Commits";
   const PR_TITLE_NOT_COMPLIANT_MSG = "pull request title is not compliant";


### PR DESCRIPTION
I would like to be able to run the commisery action during a run  for a PR on the Merge Queue.

We can probably assume there is no need to run this check for the merge_group trigger (inside the Merge Queue), there should be no changes to the commits after all status checks are green for the PR, and the PR is just staged for merging (Merge when ready).

From other hand, since the check is fast, it won't hurt.

This PR sends the warning away for runs in the Merge Queue and let consumers decide if they would prefer to run it conditionally only for one event type.