### PR TITLE
improvement: allow default Git revert commits

### DIFF
--- a/dist/bump/index.js
+++ b/dist/bump/index.js
@@ -32400,12 +32400,15 @@ class ConventionalCommitMessage {
     type;
     constructor(message, hexsha = undefined, config = new config_1.Configuration()) {
         const splitMessage = stripMessage(message).split(os.EOL);
-        // Skip Mere and Fixup commits
+        // Skip merge-, fixup- and revert-commits
         if (isMerge(splitMessage[0])) {
             throw new errors_1.MergeCommitError();
         }
         if (isFixup(splitMessage[0])) {
             throw new errors_1.FixupCommitError();
+        }
+        if (isRevert(splitMessage[0])) {
+            throw new errors_1.RevertCommitError();
         }
         this.hexsha = hexsha;
         this.config = config;
@@ -32459,12 +32462,13 @@ class ConventionalCommitMessage {
 }
 exports.ConventionalCommitMessage = ConventionalCommitMessage;
 function isFixup(subject) {
-    const AUTOSQUASH_REGEX = /^(?:(?:fixup|squash)!\s+)+/;
-    return AUTOSQUASH_REGEX.test(subject);
+    return /^(?:(?:fixup|squash)!\s+)+/.test(subject);
 }
 function isMerge(subject) {
-    const MERGE_REGEX = /^Merge.*?:?[\s\t]*?/;
-    return MERGE_REGEX.test(subject);
+    return /^Merge.*?:?[\s\t]*?/.test(subject);
+}
+function isRevert(subject) {
+    return /^Revert "/.test(subject);
 }
 function stripMessage(message) {
     const cutLine = message.indexOf("# ------------------------ >8 ------------------------\n");
@@ -32895,7 +32899,7 @@ exports._testData = {
  * limitations under the License.
  */
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.BumpError = exports.FixupCommitError = exports.MergeCommitError = exports.ConventionalCommitError = void 0;
+exports.BumpError = exports.RevertCommitError = exports.FixupCommitError = exports.MergeCommitError = exports.ConventionalCommitError = void 0;
 class ConventionalCommitError extends Error {
     errors;
     constructor(message, errors) {
@@ -32907,18 +32911,25 @@ class ConventionalCommitError extends Error {
 exports.ConventionalCommitError = ConventionalCommitError;
 class MergeCommitError extends Error {
     constructor() {
-        super("Commit Message is a 'merge' commit!");
+        super("Commit message describes a 'merge' commit!");
         this.name = "MergeCommitError";
     }
 }
 exports.MergeCommitError = MergeCommitError;
 class FixupCommitError extends Error {
     constructor() {
-        super("Commit Message is a 'fixup' commit!");
+        super("Commit message describes a 'fixup' commit!");
         this.name = "FixupCommitError";
     }
 }
 exports.FixupCommitError = FixupCommitError;
+class RevertCommitError extends Error {
+    constructor() {
+        super("Commit message describes a 'revert' commit!");
+        this.name = "RevertCommitError";
+    }
+}
+exports.RevertCommitError = RevertCommitError;
 class BumpError extends Error {
     constructor(msg) {
         super(`Error while applying version bump: ${msg}`);
@@ -34694,7 +34705,8 @@ function processCommits(commits, config) {
                 continue;
             }
             else if (error instanceof errors_1.MergeCommitError ||
-                error instanceof errors_1.FixupCommitError) {
+                error instanceof errors_1.FixupCommitError ||
+                error instanceof errors_1.RevertCommitError) {
                 continue;
             }
             throw error;
@@ -34754,6 +34766,14 @@ async function validatePrTitle(_) {
             errorMessage = `${errorMessage} (it describes a ${error instanceof errors_1.MergeCommitError ? "merge" : "fixup"} commit)`;
             core.setFailed(errorMessage);
             return undefined;
+        }
+        else if (error instanceof errors_1.RevertCommitError) {
+            // We'll allow revert commit-like PR titles, as they are the default for
+            // GitHub's "Revert" button.
+            core.startGroup("The pull request title describes a revert, which is allowed.");
+            core.info(prTitleText);
+            core.endGroup();
+            return new commit_1.ConventionalCommitMessage("revert: placeholder");
         }
         else {
             throw error;

--- a/dist/cli/index.js
+++ b/dist/cli/index.js
@@ -33590,12 +33590,15 @@ class ConventionalCommitMessage {
     type;
     constructor(message, hexsha = undefined, config = new config_1.Configuration()) {
         const splitMessage = stripMessage(message).split(os.EOL);
-        // Skip Mere and Fixup commits
+        // Skip merge-, fixup- and revert-commits
         if (isMerge(splitMessage[0])) {
             throw new errors_1.MergeCommitError();
         }
         if (isFixup(splitMessage[0])) {
             throw new errors_1.FixupCommitError();
+        }
+        if (isRevert(splitMessage[0])) {
+            throw new errors_1.RevertCommitError();
         }
         this.hexsha = hexsha;
         this.config = config;
@@ -33649,12 +33652,13 @@ class ConventionalCommitMessage {
 }
 exports.ConventionalCommitMessage = ConventionalCommitMessage;
 function isFixup(subject) {
-    const AUTOSQUASH_REGEX = /^(?:(?:fixup|squash)!\s+)+/;
-    return AUTOSQUASH_REGEX.test(subject);
+    return /^(?:(?:fixup|squash)!\s+)+/.test(subject);
 }
 function isMerge(subject) {
-    const MERGE_REGEX = /^Merge.*?:?[\s\t]*?/;
-    return MERGE_REGEX.test(subject);
+    return /^Merge.*?:?[\s\t]*?/.test(subject);
+}
+function isRevert(subject) {
+    return /^Revert "/.test(subject);
 }
 function stripMessage(message) {
     const cutLine = message.indexOf("# ------------------------ >8 ------------------------\n");
@@ -34085,7 +34089,7 @@ exports._testData = {
  * limitations under the License.
  */
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.BumpError = exports.FixupCommitError = exports.MergeCommitError = exports.ConventionalCommitError = void 0;
+exports.BumpError = exports.RevertCommitError = exports.FixupCommitError = exports.MergeCommitError = exports.ConventionalCommitError = void 0;
 class ConventionalCommitError extends Error {
     errors;
     constructor(message, errors) {
@@ -34097,18 +34101,25 @@ class ConventionalCommitError extends Error {
 exports.ConventionalCommitError = ConventionalCommitError;
 class MergeCommitError extends Error {
     constructor() {
-        super("Commit Message is a 'merge' commit!");
+        super("Commit message describes a 'merge' commit!");
         this.name = "MergeCommitError";
     }
 }
 exports.MergeCommitError = MergeCommitError;
 class FixupCommitError extends Error {
     constructor() {
-        super("Commit Message is a 'fixup' commit!");
+        super("Commit message describes a 'fixup' commit!");
         this.name = "FixupCommitError";
     }
 }
 exports.FixupCommitError = FixupCommitError;
+class RevertCommitError extends Error {
+    constructor() {
+        super("Commit message describes a 'revert' commit!");
+        this.name = "RevertCommitError";
+    }
+}
+exports.RevertCommitError = RevertCommitError;
 class BumpError extends Error {
     constructor(msg) {
         super(`Error while applying version bump: ${msg}`);

--- a/dist/validate/index.js
+++ b/dist/validate/index.js
@@ -32358,12 +32358,15 @@ class ConventionalCommitMessage {
     type;
     constructor(message, hexsha = undefined, config = new config_1.Configuration()) {
         const splitMessage = stripMessage(message).split(os.EOL);
-        // Skip Mere and Fixup commits
+        // Skip merge-, fixup- and revert-commits
         if (isMerge(splitMessage[0])) {
             throw new errors_1.MergeCommitError();
         }
         if (isFixup(splitMessage[0])) {
             throw new errors_1.FixupCommitError();
+        }
+        if (isRevert(splitMessage[0])) {
+            throw new errors_1.RevertCommitError();
         }
         this.hexsha = hexsha;
         this.config = config;
@@ -32417,12 +32420,13 @@ class ConventionalCommitMessage {
 }
 exports.ConventionalCommitMessage = ConventionalCommitMessage;
 function isFixup(subject) {
-    const AUTOSQUASH_REGEX = /^(?:(?:fixup|squash)!\s+)+/;
-    return AUTOSQUASH_REGEX.test(subject);
+    return /^(?:(?:fixup|squash)!\s+)+/.test(subject);
 }
 function isMerge(subject) {
-    const MERGE_REGEX = /^Merge.*?:?[\s\t]*?/;
-    return MERGE_REGEX.test(subject);
+    return /^Merge.*?:?[\s\t]*?/.test(subject);
+}
+function isRevert(subject) {
+    return /^Revert "/.test(subject);
 }
 function stripMessage(message) {
     const cutLine = message.indexOf("# ------------------------ >8 ------------------------\n");
@@ -32853,7 +32857,7 @@ exports._testData = {
  * limitations under the License.
  */
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.BumpError = exports.FixupCommitError = exports.MergeCommitError = exports.ConventionalCommitError = void 0;
+exports.BumpError = exports.RevertCommitError = exports.FixupCommitError = exports.MergeCommitError = exports.ConventionalCommitError = void 0;
 class ConventionalCommitError extends Error {
     errors;
     constructor(message, errors) {
@@ -32865,18 +32869,25 @@ class ConventionalCommitError extends Error {
 exports.ConventionalCommitError = ConventionalCommitError;
 class MergeCommitError extends Error {
     constructor() {
-        super("Commit Message is a 'merge' commit!");
+        super("Commit message describes a 'merge' commit!");
         this.name = "MergeCommitError";
     }
 }
 exports.MergeCommitError = MergeCommitError;
 class FixupCommitError extends Error {
     constructor() {
-        super("Commit Message is a 'fixup' commit!");
+        super("Commit message describes a 'fixup' commit!");
         this.name = "FixupCommitError";
     }
 }
 exports.FixupCommitError = FixupCommitError;
+class RevertCommitError extends Error {
+    constructor() {
+        super("Commit message describes a 'revert' commit!");
+        this.name = "RevertCommitError";
+    }
+}
+exports.RevertCommitError = RevertCommitError;
 class BumpError extends Error {
     constructor(msg) {
         super(`Error while applying version bump: ${msg}`);
@@ -34652,7 +34663,8 @@ function processCommits(commits, config) {
                 continue;
             }
             else if (error instanceof errors_1.MergeCommitError ||
-                error instanceof errors_1.FixupCommitError) {
+                error instanceof errors_1.FixupCommitError ||
+                error instanceof errors_1.RevertCommitError) {
                 continue;
             }
             throw error;
@@ -34712,6 +34724,14 @@ async function validatePrTitle(_) {
             errorMessage = `${errorMessage} (it describes a ${error instanceof errors_1.MergeCommitError ? "merge" : "fixup"} commit)`;
             core.setFailed(errorMessage);
             return undefined;
+        }
+        else if (error instanceof errors_1.RevertCommitError) {
+            // We'll allow revert commit-like PR titles, as they are the default for
+            // GitHub's "Revert" button.
+            core.startGroup("The pull request title describes a revert, which is allowed.");
+            core.info(prTitleText);
+            core.endGroup();
+            return new commit_1.ConventionalCommitMessage("revert: placeholder");
         }
         else {
             throw error;

--- a/src/commit.ts
+++ b/src/commit.ts
@@ -20,6 +20,7 @@ import {
   ConventionalCommitError,
   FixupCommitError,
   MergeCommitError,
+  RevertCommitError,
 } from "./errors";
 import { SemVerType } from "./semver";
 
@@ -178,13 +179,17 @@ export class ConventionalCommitMessage {
   ) {
     const splitMessage: string[] = stripMessage(message).split(os.EOL);
 
-    // Skip Mere and Fixup commits
+    // Skip merge-, fixup- and revert-commits
     if (isMerge(splitMessage[0])) {
       throw new MergeCommitError();
     }
 
     if (isFixup(splitMessage[0])) {
       throw new FixupCommitError();
+    }
+
+    if (isRevert(splitMessage[0])) {
+      throw new RevertCommitError();
     }
 
     this.hexsha = hexsha;
@@ -257,13 +262,15 @@ export class ConventionalCommitMessage {
 }
 
 function isFixup(subject: string): boolean {
-  const AUTOSQUASH_REGEX = /^(?:(?:fixup|squash)!\s+)+/;
-  return AUTOSQUASH_REGEX.test(subject);
+  return /^(?:(?:fixup|squash)!\s+)+/.test(subject);
 }
 
 function isMerge(subject: string): boolean {
-  const MERGE_REGEX = /^Merge.*?:?[\s\t]*?/;
-  return MERGE_REGEX.test(subject);
+  return /^Merge.*?:?[\s\t]*?/.test(subject);
+}
+
+function isRevert(subject: string): boolean {
+  return /^Revert "/.test(subject);
 }
 
 function stripMessage(message: string): string {

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -28,15 +28,22 @@ export class ConventionalCommitError extends Error {
 
 export class MergeCommitError extends Error {
   constructor() {
-    super("Commit Message is a 'merge' commit!");
+    super("Commit message describes a 'merge' commit!");
     this.name = "MergeCommitError";
   }
 }
 
 export class FixupCommitError extends Error {
   constructor() {
-    super("Commit Message is a 'fixup' commit!");
+    super("Commit message describes a 'fixup' commit!");
     this.name = "FixupCommitError";
+  }
+}
+
+export class RevertCommitError extends Error {
+  constructor() {
+    super("Commit message describes a 'revert' commit!");
+    this.name = "RevertCommitError";
   }
 }
 

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -30,6 +30,7 @@ import {
   ConventionalCommitError,
   FixupCommitError,
   MergeCommitError,
+  RevertCommitError,
 } from "./errors";
 
 interface ValidationResult {
@@ -124,7 +125,8 @@ export function processCommits(
         continue;
       } else if (
         error instanceof MergeCommitError ||
-        error instanceof FixupCommitError
+        error instanceof FixupCommitError ||
+        error instanceof RevertCommitError
       ) {
         continue;
       }
@@ -204,6 +206,13 @@ export async function validatePrTitle(
       } commit)`;
       core.setFailed(errorMessage);
       return undefined;
+    } else if (error instanceof RevertCommitError) {
+      // We'll allow revert commit-like PR titles, as they are the default for
+      // GitHub's "Revert" button.
+      core.startGroup("The pull request title describes a revert, which is allowed.");
+      core.info(prTitleText);
+      core.endGroup();
+      return new ConventionalCommitMessage("revert: placeholder");
     } else {
       throw error;
     }

--- a/test/commit.test.ts
+++ b/test/commit.test.ts
@@ -22,6 +22,7 @@ import {
   ConventionalCommitError,
   FixupCommitError,
   MergeCommitError,
+  RevertCommitError,
 } from "../src/errors";
 
 // Validate non-compliant Commit Messages
@@ -37,6 +38,12 @@ describe("Non-compliant Commit Messages", () => {
     expect(() => {
       new ConventionalCommitMessage("fixup! feat: add new feature");
     }).toThrow(FixupCommitError);
+  });
+
+  test("Revert commit", () => {
+    expect(() => {
+      new ConventionalCommitMessage("Revert \"feat: add new feature\"");
+    }).toThrow(RevertCommitError);
   });
 
   test("Non-Conventional Commit message", () => {

--- a/test/test_utils.ts
+++ b/test/test_utils.ts
@@ -32,6 +32,7 @@ export const NONE_MSG2 = toICommit(
   "refactor: make something easier to maintain"
 );
 export const NONE_MSG3 = toICommit("build: make something more efficiently");
+export const REVERT_MSG = toICommit("Revert \"perf: make something faster\"");
 export const PRTITLE = (type_: string) => `${type_}: simple PR title`;
 
 export const INITIAL_VERSION = "1.2.3";
@@ -45,6 +46,7 @@ export const BASE_COMMIT = { message: "chore: base commit", sha: "f00dcafe" };
 export const CHANGELOG_PLACEHOLDER = "CHANGELOG_PLACEHOLDER";
 
 export const DEFAULT_COMMIT_LIST = [
+  REVERT_MSG,
   NONE_MSG1,
   NONE_MSG2,
   NONE_MSG3,


### PR DESCRIPTION
This change will stop Commisery-Action complaining about revert commits
using the default Git string:
```
Revert "chore: some earlier commit"
```

Although it'd be preferred to amend the revert describing the reason,
this is cumbersome for people using the GitHub web interface, as GitHub
doesn't allow for editing the actual commit message when pressing the
"Revert" button.

Addresses #271