### PR TITLE
ci: remove path-filters from check-dist

### DIFF
--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -28,11 +28,7 @@ on:
   push:
     branches:
       - main
-    paths-ignore:
-      - '**.md'
   pull_request:
-    paths-ignore:
-      - '**.md'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
The branch protection rules require check-dist to be completed before merging is allowed - this filter is preventing the workflow to be executed in case we only change a readme file.