### PR TITLE
fix: convert release-branches regex to RegExp object

### DIFF
--- a/dist/bump/index.js
+++ b/dist/bump/index.js
@@ -32766,7 +32766,7 @@ class Configuration {
                      *   release-branches: "^release/.*\d+\.\d+.*$"
                      */
                     if (typeof data[key] === "string") {
-                        this.releaseBranches = data[key];
+                        this.releaseBranches = new RegExp(data[key]);
                     }
                     else {
                         throw new Error(`Incorrect type '${typeof data[key]}' for '${key}', must be '${typeof this.releaseBranches}'!`);

--- a/dist/cli/index.js
+++ b/dist/cli/index.js
@@ -33956,7 +33956,7 @@ class Configuration {
                      *   release-branches: "^release/.*\d+\.\d+.*$"
                      */
                     if (typeof data[key] === "string") {
-                        this.releaseBranches = data[key];
+                        this.releaseBranches = new RegExp(data[key]);
                     }
                     else {
                         throw new Error(`Incorrect type '${typeof data[key]}' for '${key}', must be '${typeof this.releaseBranches}'!`);

--- a/dist/validate/index.js
+++ b/dist/validate/index.js
@@ -32724,7 +32724,7 @@ class Configuration {
                      *   release-branches: "^release/.*\d+\.\d+.*$"
                      */
                     if (typeof data[key] === "string") {
-                        this.releaseBranches = data[key];
+                        this.releaseBranches = new RegExp(data[key]);
                     }
                     else {
                         throw new Error(`Incorrect type '${typeof data[key]}' for '${key}', must be '${typeof this.releaseBranches}'!`);

--- a/src/config.ts
+++ b/src/config.ts
@@ -307,7 +307,7 @@ export class Configuration {
            *   release-branches: "^release/.*\d+\.\d+.*$"
            */
           if (typeof data[key] === "string") {
-            this.releaseBranches = data[key];
+            this.releaseBranches = new RegExp(data[key]);
           } else {
             throw new Error(
               `Incorrect type '${typeof data[


### PR DESCRIPTION
The `release-branches` configuration parameter was passed as `string` instead of the expected `RegExp` type.