### PR TITLE
feat: add github release discussion category configuration option

### DIFF
--- a/dist/cli/index.js
+++ b/dist/cli/index.js
@@ -33772,6 +33772,7 @@ const CONFIG_ITEMS = [
     "version-prefix",
     "version-scheme",
     "release-branches",
+    "release-discussion-category",
     "prereleases",
     "sdkver-create-release-branches",
     "sdkver-max-major",
@@ -33793,6 +33794,7 @@ class Configuration {
     allowedBranches = ".*";
     maxSubjectLength = 80;
     releaseBranches = /^release\/.*\d+\.\d+\.*$/;
+    releaseDiscussionCategory = undefined;
     versionPrefix = "*";
     versionScheme = "semver";
     prereleasePrefix = undefined;
@@ -33962,6 +33964,18 @@ class Configuration {
                         throw new Error(`Incorrect type '${typeof data[key]}' for '${key}', must be '${typeof this.releaseBranches}'!`);
                     }
                     break;
+                case "release-discussion-category":
+                    /* Example YAML:
+                     *   release-discussion-category: ""
+                     *   release-discussion-category: "release notes"
+                     */
+                    if (typeof data[key] === "string") {
+                        this.releaseDiscussionCategory = data[key];
+                    }
+                    else {
+                        throw new Error(`Incorrect type '${typeof data[key]}' for '${key}', must be '${typeof this.releaseDiscussionCategory}'!`);
+                    }
+                    break;
                 case "initial-development":
                     /* Example YAML:
                      *   initial-development: true
@@ -34050,6 +34064,7 @@ class Configuration {
         config.allowedBranches = this.allowedBranches;
         config.maxSubjectLength = this.maxSubjectLength;
         config.releaseBranches = this.releaseBranches;
+        config.releaseDiscussionCategory = this.releaseDiscussionCategory;
         config.versionScheme = this.versionScheme;
         config.prereleasePrefix = this.prereleasePrefix;
         config.tags = JSON.parse(JSON.stringify(this.tags));

--- a/dist/validate/index.js
+++ b/dist/validate/index.js
@@ -31475,7 +31475,7 @@ function printNonCompliance(commits) {
     }
 }
 exports.printNonCompliance = printNonCompliance;
-async function publishBump(nextVersion, releaseMode, headSha, changelog, isBranchAllowedToPublish, updateDraftId) {
+async function publishBump(nextVersion, releaseMode, headSha, changelog, isBranchAllowedToPublish, discussionCategoryName, updateDraftId) {
     const nv = nextVersion.toString();
     core.info(`ℹ️ Next version: ${nv}`);
     core.setOutput("next-version", nv);
@@ -31511,7 +31511,7 @@ async function publishBump(nextVersion, releaseMode, headSha, changelog, isBranc
                     }
                 }
                 if (!updated) {
-                    await (0, github_1.createRelease)(nv, headSha, changelog, isDev, isRc);
+                    await (0, github_1.createRelease)(nv, headSha, changelog, isDev, isRc, discussionCategoryName);
                 }
             }
         }
@@ -31581,7 +31581,7 @@ async function bumpSemVer(config, bumpInfo, releaseMode, branchName, headSha, is
         if (buildMetadata) {
             nextVersion.build = buildMetadata;
         }
-        bumped = await publishBump(nextVersion, releaseMode, headSha, changelog, isBranchAllowedToPublish);
+        bumped = await publishBump(nextVersion, releaseMode, headSha, changelog, isBranchAllowedToPublish, config.releaseDiscussionCategory);
     }
     else {
         core.info("ℹ️ No bump necessary");
@@ -31852,7 +31852,7 @@ async function bumpSdkVer(config, bumpInfo, releaseMode, sdkVerBumpType, headSha
                 changelog = await (0, changelog_1.generateChangelog)(bumpInfo);
             }
         }
-        bumped = await publishBump(nextVersion, releaseMode, headSha, changelog, isBranchAllowedToPublish, 
+        bumped = await publishBump(nextVersion, releaseMode, headSha, changelog, isBranchAllowedToPublish, config.releaseDiscussionCategory, 
         // Re-use the latest draft release only when not running on a release branch,
         // otherwise we might randomly reset a `dev-N` number chain.
         !isReleaseBranch ? latestDraft?.id : undefined);
@@ -32540,6 +32540,7 @@ const CONFIG_ITEMS = [
     "version-prefix",
     "version-scheme",
     "release-branches",
+    "release-discussion-category",
     "prereleases",
     "sdkver-create-release-branches",
     "sdkver-max-major",
@@ -32561,6 +32562,7 @@ class Configuration {
     allowedBranches = ".*";
     maxSubjectLength = 80;
     releaseBranches = /^release\/.*\d+\.\d+\.*$/;
+    releaseDiscussionCategory = undefined;
     versionPrefix = "*";
     versionScheme = "semver";
     prereleasePrefix = undefined;
@@ -32730,6 +32732,18 @@ class Configuration {
                         throw new Error(`Incorrect type '${typeof data[key]}' for '${key}', must be '${typeof this.releaseBranches}'!`);
                     }
                     break;
+                case "release-discussion-category":
+                    /* Example YAML:
+                     *   release-discussion-category: ""
+                     *   release-discussion-category: "release notes"
+                     */
+                    if (typeof data[key] === "string") {
+                        this.releaseDiscussionCategory = data[key];
+                    }
+                    else {
+                        throw new Error(`Incorrect type '${typeof data[key]}' for '${key}', must be '${typeof this.releaseDiscussionCategory}'!`);
+                    }
+                    break;
                 case "initial-development":
                     /* Example YAML:
                      *   initial-development: true
@@ -32818,6 +32832,7 @@ class Configuration {
         config.allowedBranches = this.allowedBranches;
         config.maxSubjectLength = this.maxSubjectLength;
         config.releaseBranches = this.releaseBranches;
+        config.releaseDiscussionCategory = this.releaseDiscussionCategory;
         config.versionScheme = this.versionScheme;
         config.prereleasePrefix = this.prereleasePrefix;
         config.tags = JSON.parse(JSON.stringify(this.tags));
@@ -33029,13 +33044,16 @@ exports.getPullRequest = getPullRequest;
  * @param commitish The commitish (ref, sha, ..) the release shall be made from
  * @param body The release's text description
  * @param draft Create this release as a 'draft' release
+ * @param prerelease Create this release as a prerelease
+ * @param discussionCategory Create this release with link to this discussion category
  */
-async function createRelease(tagName, commitish, body, draft, prerelease) {
+async function createRelease(tagName, commitish, body, draft, prerelease, discussionCategory) {
     await getOctokit().rest.repos.createRelease({
         ...github.context.repo,
         tag_name: tagName,
         target_commitish: commitish,
         name: tagName,
+        discussion_category_name: discussionCategory,
         body,
         draft,
         prerelease,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -32,6 +32,7 @@ initial-development: false  # OPTIONAL, defaults to `true`
 | `version-prefix` | `"*"` | An optional prefix specifying the tags to consider. "*" is a special value, meaning the closest version is used, regardless of prefix |
 | `version-scheme` | `semver` | The versioning scheme to use. Supported values: `semver`, `sdkver`. |
 | `release-branches` | `/^release\/.*\d+\.\d+\.*$/` | A regex specifying from which branch(es) only `PATCH` version bump are allowed. |
+| `release-discussion-category` | `undefined` | A string specifying an existing GitHub discussion category name. This requires GitHub discussions to be enabled on the repository. |
 | `prereleases` | `undefined` | A string specifying the prereleases prefix. |
 | `sdkver-create-release-branches` | `false` | For SdkVer versioning scheme only: push a new branch if an RC or release build is performed on a non-release branch. If this config value is boolean `true`, the branch shall be of the form `release/N.N`. If this value is set to a string, it shall be used as the branch name prefix and appended with the major and minor release numbers, e.g. config value  `"rel/"` results in a branch named `rel/N.N`. |
 | `sdkver-max-major` | `0` | For SdkVer versioning scheme only: do not bump major version when breaking changes are found in case the maximum configured major version is already reached. |

--- a/src/bump.ts
+++ b/src/bump.ts
@@ -367,6 +367,7 @@ export async function publishBump(
   headSha: string,
   changelog: string,
   isBranchAllowedToPublish: boolean,
+  discussionCategoryName?: string,
   updateDraftId?: number
 ): Promise<boolean> {
   const nv = nextVersion.toString();
@@ -415,7 +416,14 @@ export async function publishBump(
           }
         }
         if (!updated) {
-          await createRelease(nv, headSha, changelog, isDev, isRc);
+          await createRelease(
+            nv,
+            headSha,
+            changelog,
+            isDev,
+            isRc,
+            discussionCategoryName
+          );
         }
       }
     } catch (ex: unknown) {
@@ -513,7 +521,8 @@ export async function bumpSemVer(
       releaseMode,
       headSha,
       changelog,
-      isBranchAllowedToPublish
+      isBranchAllowedToPublish,
+      config.releaseDiscussionCategory
     );
   } else {
     core.info("ℹ️ No bump necessary");
@@ -861,6 +870,7 @@ export async function bumpSdkVer(
       headSha,
       changelog,
       isBranchAllowedToPublish,
+      config.releaseDiscussionCategory,
       // Re-use the latest draft release only when not running on a release branch,
       // otherwise we might randomly reset a `dev-N` number chain.
       !isReleaseBranch ? latestDraft?.id : undefined

--- a/src/config.ts
+++ b/src/config.ts
@@ -72,6 +72,7 @@ const CONFIG_ITEMS = [
   "version-prefix",
   "version-scheme",
   "release-branches",
+  "release-discussion-category",
   "prereleases",
   "sdkver-create-release-branches",
   "sdkver-max-major",
@@ -102,6 +103,7 @@ export class Configuration {
   allowedBranches = ".*";
   maxSubjectLength = 80;
   releaseBranches = /^release\/.*\d+\.\d+\.*$/;
+  releaseDiscussionCategory?: string = undefined;
   versionPrefix = "*";
   versionScheme = "semver";
   prereleasePrefix?: string = undefined;
@@ -317,6 +319,22 @@ export class Configuration {
           }
           break;
 
+        case "release-discussion-category":
+          /* Example YAML:
+           *   release-discussion-category: ""
+           *   release-discussion-category: "release notes"
+           */
+          if (typeof data[key] === "string") {
+            this.releaseDiscussionCategory = data[key];
+          } else {
+            throw new Error(
+              `Incorrect type '${typeof data[
+                key
+              ]}' for '${key}', must be '${typeof this.releaseDiscussionCategory}'!`
+            );
+          }
+          break;
+
         case "initial-development":
           /* Example YAML:
            *   initial-development: true
@@ -424,6 +442,7 @@ export class Configuration {
     config.allowedBranches = this.allowedBranches;
     config.maxSubjectLength = this.maxSubjectLength;
     config.releaseBranches = this.releaseBranches;
+    config.releaseDiscussionCategory = this.releaseDiscussionCategory;
     config.versionScheme = this.versionScheme;
     config.prereleasePrefix = this.prereleasePrefix;
     config.tags = JSON.parse(JSON.stringify(this.tags));

--- a/src/github.ts
+++ b/src/github.ts
@@ -115,19 +115,23 @@ export async function getPullRequest(
  * @param commitish The commitish (ref, sha, ..) the release shall be made from
  * @param body The release's text description
  * @param draft Create this release as a 'draft' release
+ * @param prerelease Create this release as a prerelease
+ * @param discussionCategory Create this release with link to this discussion category
  */
 export async function createRelease(
   tagName: string,
   commitish: string,
   body: string,
   draft: boolean,
-  prerelease: boolean
+  prerelease: boolean,
+  discussionCategory?: string
 ): Promise<void> {
   await getOctokit().rest.repos.createRelease({
     ...github.context.repo,
     tag_name: tagName,
     target_commitish: commitish,
     name: tagName,
+    discussion_category_name: discussionCategory,
     body,
     draft,
     prerelease,

--- a/test/bump.sdkver.test.ts
+++ b/test/bump.sdkver.test.ts
@@ -173,9 +173,13 @@ const testFunction = async (p: SdkBumpTestParameters) => {
       U.HEAD_SHA,
       U.CHANGELOG_PLACEHOLDER,
       p.expectedVersion.includes("-dev"), // draft
-      p.expectedVersion.includes("-rc") // prerelease
+      p.expectedVersion.includes("-rc"), // prerelease
+      undefined
     );
-    expect(core.setOutput).toBeCalledWith("next-version", p.expectedVersion);
+    expect(core.setOutput).toHaveBeenCalledWith(
+      "next-version",
+      p.expectedVersion
+    );
     expect(core.error).not.toHaveBeenCalled();
     expect(core.setFailed).not.toHaveBeenCalled();
   } else {
@@ -187,7 +191,10 @@ const testFunction = async (p: SdkBumpTestParameters) => {
       expect(github.createRelease).not.toHaveBeenCalled();
     }
   }
-  expect(core.setOutput).toBeCalledWith("current-version", p.initialVersion);
+  expect(core.setOutput).toHaveBeenCalledWith(
+    "current-version",
+    p.initialVersion
+  );
 };
 
 // prettier-ignore
@@ -465,7 +472,8 @@ describe("Create changelog", () => {
         U.HEAD_SHA,
         U.CHANGELOG_PLACEHOLDER,
         false,
-        false
+        false,
+        undefined
       );
     } else {
       expect(changelog.generateChangelog).not.toHaveBeenCalled();
@@ -475,7 +483,8 @@ describe("Create changelog", () => {
         U.HEAD_SHA,
         "",
         false,
-        false
+        false,
+        undefined
       );
     }
   });

--- a/test/bump.test.ts
+++ b/test/bump.test.ts
@@ -153,7 +153,8 @@ describe("Bump functionality", () => {
           U.HEAD_SHA,
           U.CHANGELOG_PLACEHOLDER,
           false,
-          false
+          false,
+          undefined
         );
       }
       expect(core.setOutput).toBeCalledWith(
@@ -456,7 +457,8 @@ describe("Initial development", () => {
       U.HEAD_SHA,
       U.CHANGELOG_PLACEHOLDER,
       false,
-      false
+      false,
+      undefined
     );
 
     expect(core.error).not.toHaveBeenCalled();
@@ -503,7 +505,8 @@ describe("Create changelog", () => {
         U.HEAD_SHA,
         U.CHANGELOG_PLACEHOLDER,
         false,
-        false
+        false,
+        undefined
       );
     } else {
       expect(changelog.generateChangelog).not.toHaveBeenCalled();
@@ -513,7 +516,8 @@ describe("Create changelog", () => {
         U.HEAD_SHA,
         "",
         false,
-        false
+        false,
+        undefined
       );
     }
   });


### PR DESCRIPTION
This allows to enable to create a discussion from a GitHub release. See: https://github.blog/changelog/2021-04-06-releases-support-comments-and-reactions-with-discussion-linking/