### PR TITLE
fix: set outputs in case of no tag and release publication

### DIFF
--- a/dist/bump/index.js
+++ b/dist/bump/index.js
@@ -33600,8 +33600,8 @@ async function bumpSemVer(config, bumpInfo, releaseMode, branchName, headSha, is
                 to: bumpMetadata.to.toString(),
                 type: bumpMetadata.type,
             },
-            release,
             tag,
+            release,
         };
         // If we have a release and/or a tag, we consider the bump successful
         bumped = release !== undefined || tag !== undefined;

--- a/dist/bump/index.js
+++ b/dist/bump/index.js
@@ -33583,26 +33583,25 @@ async function bumpSemVer(config, bumpInfo, releaseMode, branchName, headSha, is
             };
         }
     }
-    let versionMetadata;
     let bumped = false;
     let changelog = "";
     if (createChangelog)
         changelog = await (0, changelog_1.generateChangelog)(bumpInfo);
+    let versionMetadata;
     if (bumpMetadata) {
-        const buildMetadata = core.getInput("build-metadata");
-        if (buildMetadata) {
-            bumpMetadata.to.build = buildMetadata;
-        }
-        const { release, tag } = await publishBump(bumpMetadata.to, releaseMode, headSha, changelog, isBranchAllowedToPublish, config.releaseDiscussionCategory);
         versionMetadata = {
             bump: {
                 from: bumpMetadata.from.toString(),
                 to: bumpMetadata.to.toString(),
                 type: bumpMetadata.type,
             },
-            tag,
-            release,
         };
+        const buildMetadata = core.getInput("build-metadata");
+        if (buildMetadata) {
+            bumpMetadata.to.build = buildMetadata;
+        }
+        const { release, tag } = await publishBump(bumpMetadata.to, releaseMode, headSha, changelog, isBranchAllowedToPublish, config.releaseDiscussionCategory);
+        versionMetadata = { ...versionMetadata, release, tag };
         // If we have a release and/or a tag, we consider the bump successful
         bumped = release !== undefined || tag !== undefined;
     }
@@ -33644,7 +33643,7 @@ async function bumpSemVer(config, bumpInfo, releaseMode, branchName, headSha, is
             core.info(`ℹ️ While configured to bump prereleases, ${reason}.`);
         }
     }
-    return bumped ? versionMetadata : undefined;
+    return bumped || releaseMode === "none" ? versionMetadata : undefined;
 }
 exports.bumpSemVer = bumpSemVer;
 function getNextSdkVer(currentVersion, sdkVerBumpType, isReleaseBranch, headMatchesTag, hasBreakingChange, devPrereleaseText, headSha, isInitialDevelopment) {
@@ -33871,6 +33870,13 @@ async function bumpSdkVer(config, bumpInfo, releaseMode, sdkVerBumpType, headSha
     let releaseBranchName;
     let versionOutput;
     if (bump?.to) {
+        versionOutput = {
+            bump: {
+                from: bumpInfo.foundVersion.toString(),
+                to: bump.to.toString(),
+                type: bump.type,
+            },
+        };
         // Since we want the changelog since the last _full_ release, we
         // can only rely on the `bumpInfo` if the "current version" is a
         // full release. In other cases, we need to gather some information
@@ -33901,15 +33907,7 @@ async function bumpSdkVer(config, bumpInfo, releaseMode, sdkVerBumpType, headSha
         // Re-use the latest draft release only when not running on a release branch,
         // otherwise we might randomly reset a `dev-N` number chain.
         !isReleaseBranch ? latestDraft?.id : undefined);
-        versionOutput = {
-            tag,
-            release,
-            bump: {
-                from: bumpInfo.foundVersion.toString(),
-                to: bump.to.toString(),
-                type: bump.type,
-            },
-        };
+        versionOutput = { ...versionOutput, tag, release };
         // If we have a release and/or a tag, we consider the bump successful
         bumped = release !== undefined || tag !== undefined;
     }
@@ -33948,7 +33946,7 @@ async function bumpSdkVer(config, bumpInfo, releaseMode, sdkVerBumpType, headSha
         }
     }
     core.endGroup();
-    return bumped ? versionOutput : undefined;
+    return bumped || releaseMode === "none" ? versionOutput : undefined;
 }
 exports.bumpSdkVer = bumpSdkVer;
 /**

--- a/dist/bump/index.js
+++ b/dist/bump/index.js
@@ -33583,25 +33583,26 @@ async function bumpSemVer(config, bumpInfo, releaseMode, branchName, headSha, is
             };
         }
     }
+    let versionMetadata;
     let bumped = false;
     let changelog = "";
     if (createChangelog)
         changelog = await (0, changelog_1.generateChangelog)(bumpInfo);
-    let versionMetadata;
     if (bumpMetadata) {
+        const buildMetadata = core.getInput("build-metadata");
+        if (buildMetadata) {
+            bumpMetadata.to.build = buildMetadata;
+        }
+        const { release, tag } = await publishBump(bumpMetadata.to, releaseMode, headSha, changelog, isBranchAllowedToPublish, config.releaseDiscussionCategory);
         versionMetadata = {
             bump: {
                 from: bumpMetadata.from.toString(),
                 to: bumpMetadata.to.toString(),
                 type: bumpMetadata.type,
             },
+            release,
+            tag,
         };
-        const buildMetadata = core.getInput("build-metadata");
-        if (buildMetadata) {
-            bumpMetadata.to.build = buildMetadata;
-        }
-        const { release, tag } = await publishBump(bumpMetadata.to, releaseMode, headSha, changelog, isBranchAllowedToPublish, config.releaseDiscussionCategory);
-        versionMetadata = { ...versionMetadata, release, tag };
         // If we have a release and/or a tag, we consider the bump successful
         bumped = release !== undefined || tag !== undefined;
     }
@@ -33870,13 +33871,6 @@ async function bumpSdkVer(config, bumpInfo, releaseMode, sdkVerBumpType, headSha
     let releaseBranchName;
     let versionOutput;
     if (bump?.to) {
-        versionOutput = {
-            bump: {
-                from: bumpInfo.foundVersion.toString(),
-                to: bump.to.toString(),
-                type: bump.type,
-            },
-        };
         // Since we want the changelog since the last _full_ release, we
         // can only rely on the `bumpInfo` if the "current version" is a
         // full release. In other cases, we need to gather some information
@@ -33907,7 +33901,15 @@ async function bumpSdkVer(config, bumpInfo, releaseMode, sdkVerBumpType, headSha
         // Re-use the latest draft release only when not running on a release branch,
         // otherwise we might randomly reset a `dev-N` number chain.
         !isReleaseBranch ? latestDraft?.id : undefined);
-        versionOutput = { ...versionOutput, tag, release };
+        versionOutput = {
+            bump: {
+                from: bumpInfo.foundVersion.toString(),
+                to: bump.to.toString(),
+                type: bump.type,
+            },
+            tag,
+            release,
+        };
         // If we have a release and/or a tag, we consider the bump successful
         bumped = release !== undefined || tag !== undefined;
     }

--- a/dist/validate/index.js
+++ b/dist/validate/index.js
@@ -33535,8 +33535,8 @@ async function bumpSemVer(config, bumpInfo, releaseMode, branchName, headSha, is
                 to: bumpMetadata.to.toString(),
                 type: bumpMetadata.type,
             },
-            release,
             tag,
+            release,
         };
         // If we have a release and/or a tag, we consider the bump successful
         bumped = release !== undefined || tag !== undefined;

--- a/src/bump.ts
+++ b/src/bump.ts
@@ -544,6 +544,7 @@ export async function bumpSemVer(
   }
 
   let versionMetadata: IVersionOutput | undefined;
+
   let bumped = false;
 
   let changelog = "";
@@ -570,8 +571,8 @@ export async function bumpSemVer(
         to: bumpMetadata.to.toString(),
         type: bumpMetadata.type as ReleaseType,
       },
-      release,
       tag,
+      release,
     };
 
     // If we have a release and/or a tag, we consider the bump successful

--- a/src/bump.ts
+++ b/src/bump.ts
@@ -543,21 +543,13 @@ export async function bumpSemVer(
     }
   }
 
+  let versionMetadata: IVersionOutput | undefined;
   let bumped = false;
 
   let changelog = "";
   if (createChangelog) changelog = await generateChangelog(bumpInfo);
 
-  let versionMetadata: IVersionOutput | undefined;
   if (bumpMetadata) {
-    versionMetadata = {
-      bump: {
-        from: bumpMetadata.from.toString(),
-        to: bumpMetadata.to.toString(),
-        type: bumpMetadata.type as ReleaseType,
-      },
-    };
-
     const buildMetadata = core.getInput("build-metadata");
     if (buildMetadata) {
       bumpMetadata.to.build = buildMetadata;
@@ -572,7 +564,15 @@ export async function bumpSemVer(
       config.releaseDiscussionCategory
     );
 
-    versionMetadata = { ...versionMetadata, release, tag };
+    versionMetadata = {
+      bump: {
+        from: bumpMetadata.from.toString(),
+        to: bumpMetadata.to.toString(),
+        type: bumpMetadata.type as ReleaseType,
+      },
+      release,
+      tag,
+    };
 
     // If we have a release and/or a tag, we consider the bump successful
     bumped = release !== undefined || tag !== undefined;
@@ -906,14 +906,6 @@ export async function bumpSdkVer(
   let versionOutput: IVersionOutput | undefined;
 
   if (bump?.to) {
-    versionOutput = {
-      bump: {
-        from: bumpInfo.foundVersion.toString(),
-        to: bump.to.toString(),
-        type: bump.type as ReleaseType,
-      },
-    };
-
     // Since we want the changelog since the last _full_ release, we
     // can only rely on the `bumpInfo` if the "current version" is a
     // full release. In other cases, we need to gather some information
@@ -962,7 +954,15 @@ export async function bumpSdkVer(
       !isReleaseBranch ? latestDraft?.id : undefined
     );
 
-    versionOutput = { ...versionOutput, tag, release };
+    versionOutput = {
+      bump: {
+        from: bumpInfo.foundVersion.toString(),
+        to: bump.to.toString(),
+        type: bump.type as ReleaseType,
+      },
+      tag,
+      release,
+    };
 
     // If we have a release and/or a tag, we consider the bump successful
     bumped = release !== undefined || tag !== undefined;

--- a/test/bump.sdkver.test.ts
+++ b/test/bump.sdkver.test.ts
@@ -209,13 +209,13 @@ const testFunction = async (p: SdkBumpTestParameters) => {
     expect(core.setOutput).toHaveBeenCalledWith(
       "bump-metadata",
       JSON.stringify({
-        tag,
-        release,
         bump: {
           from: p.initialVersion,
           to: p.expectedVersion,
           type: p.expectedBumpType,
         },
+        tag,
+        release,
       } as IVersionOutput)
     );
 
@@ -587,13 +587,13 @@ describe("Create changelog", () => {
     expect(core.setOutput).toHaveBeenCalledWith(
       "bump-metadata",
       JSON.stringify({
-        tag: tag,
-        release: release,
         bump: {
           from: U.INITIAL_VERSION,
           to: U.MINOR_BUMPED_VERSION,
           type: "rel",
         },
+        tag: tag,
+        release: release,
       } as IVersionOutput)
     );
   });

--- a/test/bump.test.ts
+++ b/test/bump.test.ts
@@ -189,12 +189,12 @@ describe("Bump functionality", () => {
               to: expectedVersion,
               type: expectedReleaseType,
             },
-            release,
             tag: {
               name: expectedVersion,
               ref: `refs/tags/${expectedVersion}`,
               sha: U.HEAD_SHA,
             },
+            release,
           })
         );
       } else {
@@ -306,8 +306,8 @@ describe("Releases and tags", () => {
         to: U.PATCH_BUMPED_VERSION,
         type: "patch",
       },
-      release: expectedRelease,
       tag: expectedTag,
+      release: expectedRelease,
     };
 
     expect(core.setOutput).toHaveBeenCalledWith(
@@ -420,8 +420,8 @@ describe("Trouble bumping", () => {
           to: U.PATCH_BUMPED_VERSION,
           type: "patch",
         },
-        release,
         tag,
+        release,
       })
     );
 
@@ -570,8 +570,8 @@ describe("Initial development", () => {
           to: nextVersion,
           type: "minor",
         },
-        release,
         tag,
+        release,
       })
     );
 
@@ -623,8 +623,8 @@ describe("Initial development", () => {
           to: "1.0.0",
           type: "major",
         },
-        release,
         tag,
+        release,
       })
     );
 


### PR DESCRIPTION
This change will correctly handle our commisery outputs in case `create-tag` and `create-release` are both set to `false`. This is handled by returning the VersionInformation in case we either have a successful publication (`bump === true`) _or_ we do not need to publish (`releaseMode === "none"`).