### PR TITLE
fix(bump): don't report Conventional Commit warnings for SdkVer

### DIFF
--- a/dist/bump/index.js
+++ b/dist/bump/index.js
@@ -33102,8 +33102,6 @@ async function run() {
                 core.info("This repository is under 'initial development'; breaking changes will bump the `MINOR` version.");
             }
         }
-        (0, bump_1.printNonCompliance)(bumpInfo.processedCommits);
-        core.info("");
         const createChangelog = core.getBooleanInput("create-changelog");
         const releaseTypeInput = core.getInput("release-type");
         // Variable to store the version info from either semver or sdkver bump
@@ -33112,6 +33110,8 @@ async function run() {
             if (releaseTypeInput !== "") {
                 core.warning("The input value 'release-type' has no effect when using SemVer as the version scheme.");
             }
+            (0, bump_1.printNonCompliance)(bumpInfo.processedCommits);
+            core.info("");
             core.startGroup("🔍 Determining SemVer bump");
             versionInfo = await (0, bump_1.bumpSemVer)(config, bumpInfo, releaseMode, branchName, github_1.context.sha, isBranchAllowedToPublish, createChangelog);
         }

--- a/dist/bump/index.js
+++ b/dist/bump/index.js
@@ -33095,10 +33095,12 @@ async function run() {
         core.setOutput("current-version", currentVersion);
         core.endGroup();
         if (bumpInfo.foundVersion.major <= 0) {
-            core.info("");
-            core.warning(config.initialDevelopment
-                ? "This repository is under 'initial development'; breaking changes will bump the `MINOR` version."
-                : "Enforcing version `1.0.0` as we are no longer in `initial development`.");
+            if (!config.initialDevelopment) {
+                core.warning("Enforcing version `1.0.0` as we are no longer in `initial development`.");
+            }
+            else {
+                core.info("This repository is under 'initial development'; breaking changes will bump the `MINOR` version.");
+            }
         }
         (0, bump_1.printNonCompliance)(bumpInfo.processedCommits);
         core.info("");

--- a/src/actions/bump.ts
+++ b/src/actions/bump.ts
@@ -97,12 +97,15 @@ export async function run(): Promise<void> {
     core.endGroup();
 
     if (bumpInfo.foundVersion.major <= 0) {
-      core.info("");
-      core.warning(
-        config.initialDevelopment
-          ? "This repository is under 'initial development'; breaking changes will bump the `MINOR` version."
-          : "Enforcing version `1.0.0` as we are no longer in `initial development`."
-      );
+      if (!config.initialDevelopment) {
+        core.warning(
+          "Enforcing version `1.0.0` as we are no longer in `initial development`."
+        );
+      } else {
+        core.info(
+          "This repository is under 'initial development'; breaking changes will bump the `MINOR` version."
+        );
+      }
     }
 
     printNonCompliance(bumpInfo.processedCommits);

--- a/src/actions/bump.ts
+++ b/src/actions/bump.ts
@@ -108,9 +108,6 @@ export async function run(): Promise<void> {
       }
     }
 
-    printNonCompliance(bumpInfo.processedCommits);
-    core.info("");
-
     const createChangelog = core.getBooleanInput("create-changelog");
     const releaseTypeInput = core.getInput("release-type");
 
@@ -123,6 +120,9 @@ export async function run(): Promise<void> {
           "The input value 'release-type' has no effect when using SemVer as the version scheme."
         );
       }
+      printNonCompliance(bumpInfo.processedCommits);
+      core.info("");
+
       core.startGroup("🔍 Determining SemVer bump");
       versionInfo = await bumpSemVer(
         config,

--- a/test/bump.test.ts
+++ b/test/bump.test.ts
@@ -551,7 +551,7 @@ describe("Initial development", () => {
     jest.spyOn(github, "createRelease").mockResolvedValue(release);
 
     await bumpaction.run();
-    expect(core.warning).toHaveBeenCalledWith(
+    expect(core.info).toHaveBeenCalledWith(
       expect.stringContaining("This repository is under 'initial development'")
     );
 


### PR DESCRIPTION
**-1-**
Move commit non-compliance reporting to SemVer only.
For SdkVer, we can be much more tolerant of Conventional Commit noncompliance, as there's very little ties to Conventional Commits in SdkVer anyway. So "warning"-level really isn't warranted there to the point that we might as well just remove the check.

**-2-**
Downgrade the "initial development" `warning` to `info`, but still show a warning when we're running on major version 0 _without_ being in initial development.
